### PR TITLE
setup.py: remove -j option from make command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ if platform == "linux" or platform == "linux2":
     cmd = 'cmake ..'
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
-    cmd = 'make -j'
+    cmd = 'make'
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
     clibname = "_openql.so"
@@ -28,7 +28,7 @@ elif platform == "darwin":
     cmd = 'cmake ..'
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
-    cmd = 'make -j'
+    cmd = 'make'
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
     clibname = "_openql.so"


### PR DESCRIPTION
The -j option starts an unlimited number of parallel jobs,
trashing memory and causing massive swapping to slow down
the build to hours on low-power machines or vm's.