### PR TITLE
upgraded version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ def read(fname):
 
 
 setup(name='openql',
-      version='0.1',
+      version='0.3.1',
       description='OpenQL Python Package',
       long_description=read('README.md'),
       author='I. Ashraf',


### PR DESCRIPTION
I knew we forgot something. 
I upped the version number in the pip-install to 0.3.1 (the x.x.1 is because of this being a hotfix). 

Is there any other place in the project were we track the version number? 