### PR TITLE
added if statement for CMAKE install on macOS

### DIFF
--- a/openql/CMakeLists.txt
+++ b/openql/CMakeLists.txt
@@ -21,7 +21,11 @@ SET_PROPERTY(SOURCE openql.i PROPERTY SWIG_FLAGS -castmode -modern -keyword)
 SWIG_ADD_MODULE(openql python openql.i)
 # SWIG_ADD_LIBRARY(openql LANGUAGE python SOURCES openql.i TYPE SHARED)
 
-SWIG_LINK_LIBRARIES(openql ${PYTHON_LIBRARIES} ${LEMON_LIBRARIES})
-
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    SWIG_LINK_LIBRARIES(openql ${LEMON_LIBRARIES})
+    set_target_properties(_openql PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+else ()
+    SWIG_LINK_LIBRARIES(openql ${PYTHON_LIBRARIES} ${LEMON_LIBRARIES})
+endif()
 # ADD_EXECUTABLE(apiTest test.cc)
 # TARGET_LINK_LIBRARIES(apiTest _openql.so)


### PR DESCRIPTION
Since updating my python environment on my latop I have not been able to run OpenQL, I have looked into this and it relates to the way CMAKE links python libraries. 

This pull request implements the "fix" suggested on https://stackoverflow.com/questions/50085173/swig-with-anaconda-environment-on-mac-os-throws-fatal-python-error-pythreadstat . 