### PR TITLE
Enh/parallel compilation 229

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ Or
 pip install  -e .
 ```
 
+By defining NTHREADS=N environment variable, multiple processos can be created for faster compilation. For example, the following command will create 4 processes for compilation:
+
+```
+NTHREADS=4 python setup.py install  --user
+```
+
+
 ## Running the tests
 
 In order to pass all the tests, `qisa-as` and `libqasm` should be installed first. Follow [qisa-as](https://github.com/QE-Lab/eQASM_Assembler) and [libqasm](https://github.com/QE-Lab/libqasm) instructions to install python interfaces of these modules. Once `qisa-as` and `libqasm` are installed, you can run all the tests by:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ pip install  -e .
 By defining NTHREADS=N environment variable, multiple processos can be created for faster compilation. For example, the following command will create 4 processes for compilation:
 
 ```
-NTHREADS=4 python setup.py install  --user
+NPROCS=4 python setup.py install  --user
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,16 @@ srcDir = os.path.join(rootDir, "ql")
 buildDir = os.path.join(rootDir, "cbuild")
 clibDir = os.path.join(buildDir, "openql")
 
+nprocs = 1
+env_var_nprocs = os.environ.get('NPROCS')
+if(env_var_nprocs != None):
+  nprocs = int(env_var_nprocs)
+
+print('Using {} processes for compilation'.format(nprocs))
+if nprocs == 1:
+    print('For faster compilation by N processes, set environment variable NPROCS=N')
+    print('For example: NPROCS=4 python3 setup.py install --user')
+
 if not os.path.exists(buildDir):
     os.makedirs(buildDir)
 os.chdir(buildDir)
@@ -19,7 +29,7 @@ if platform == "linux" or platform == "linux2":
     cmd = 'cmake ..'
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
-    cmd = 'make'
+    cmd = 'make -j{}'.format(nprocs)
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
     clibname = "_openql.so"
@@ -30,7 +40,7 @@ elif platform == "darwin":
     cmd = 'cmake ..'
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
-    cmd = 'make'
+    cmd = 'make -j{}'.format(nprocs)
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
     clibname = "_openql.so"
@@ -40,7 +50,7 @@ elif platform == "win32":
     cmd = 'cmake -G "NMake Makefiles" ..'
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
-    cmd = 'nmake'
+    cmd = 'nmake /MP{}'.format(nprocs)
     proc = subprocess.Popen(cmd, shell=True)
     proc.communicate()
     clibname = "_openql.pyd"


### PR DESCRIPTION
NPROCS environment variable can now be defined to control the number of processes used for launching parallel compilation jobs. for instance the following will launch 4 parallel compilation jobs:

`NPROCS=4 python setup.py install  --user`
