### PR TITLE
sweep point array deprecated

### DIFF
--- a/openql/openql.h
+++ b/openql/openql.h
@@ -295,20 +295,15 @@ public:
         program = new ql::quantum_program(name, *(platform.platform), qubit_count, creg_count);
     }
 
-    void set_sweep_points(std::vector<float> sweep_points, size_t num_sweep_points)
-    {
-        WOUT("This will soon be deprecated in favor of set_sweep_points(sweep_points)");
-        float* sp = &sweep_points[0];
-        program->set_sweep_points(sp, num_sweep_points);
-    }
-
     void set_sweep_points(std::vector<float> sweep_points)
     {
+        WOUT("This will soon be deprecated according to issue #76");
         program->sweep_points = sweep_points;
     }
 
     std::vector<float> get_sweep_points()
     {
+        WOUT("This will soon be deprecated according to issue #76");
         return program->sweep_points;
     }
 

--- a/openql/openql.i
+++ b/openql/openql.i
@@ -590,17 +590,6 @@ arg4 : int
     number of classical registers the program will use (default: 0)
 """
 
-%feature("docstring") Program::set_sweep_points
-""" Sets sweep points for an experiment.
-
-Parameters
-----------
-arg1 : []
-    list of sweep points
-arg2 : int
-    number of sweep points
-"""
-
 
 %feature("docstring") Program::set_sweep_points
 """ Sets sweep points for an experiment.

--- a/ql/program.h
+++ b/ql/program.h
@@ -540,7 +540,7 @@ class quantum_program
          }
          else
          {
-            EOUT("cannot write sweepoint file : sweep point array is empty !");
+            IOUT("sweep points file not generated as sweep point array is empty !");
          }
 
 	      IOUT("compilation of program '" << name << "' done.");

--- a/tests/test_Kernel.py
+++ b/tests/test_Kernel.py
@@ -105,7 +105,7 @@ class Test_kernel(unittest.TestCase):
         k2.measure(2)
 
         p = ql.Program("aProgram", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k1)
         p.add_kernel(k2)
 

--- a/tests/test_Program.py
+++ b/tests/test_Program.py
@@ -78,7 +78,7 @@ class Test_program(unittest.TestCase):
     # error. This test checks if an exception is indeed raised!
     def test_empty_program(self):
         p = ql.Program("rb_program", platf, 2)
-        p.set_sweep_points([2,3], 2)
+        p.set_sweep_points([2,3])
         with self.assertRaises(Exception) as cm:
             p.compile()
 
@@ -98,7 +98,7 @@ class Test_program(unittest.TestCase):
 
         sweep_points = [2]
         p = ql.Program("rb_program", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         # print( p.qasm() )
         p.compile()
@@ -121,7 +121,7 @@ class Test_program(unittest.TestCase):
 
         # sweep points is not specified the program does not work but don't
         # know what it does...
-        p.set_sweep_points([10], 10)
+        p.set_sweep_points([10])
         p.add_kernel(k)  # add kernel to program
         p.compile()
 
@@ -155,7 +155,7 @@ class Test_program(unittest.TestCase):
             k.measure(q)
 
         p.add_kernel(k)
-        p.set_sweep_points( [nr_sweep_pts], nr_sweep_pts)
+        p.set_sweep_points( [nr_sweep_pts])
 
         p.compile()
 

--- a/tests/test_barrier.py
+++ b/tests/test_barrier.py
@@ -28,7 +28,7 @@ class Test_barrier(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_barrier', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 
@@ -58,7 +58,7 @@ class Test_barrier(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_wait_barrier', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 
@@ -86,7 +86,7 @@ class Test_barrier(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_barrier_all_1', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 
@@ -132,7 +132,7 @@ class Test_barrier(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_barrier_all_2', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 
@@ -177,7 +177,7 @@ class Test_barrier(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_barrier_all_3', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -29,7 +29,7 @@ class Test_basic(unittest.TestCase):
         sweep_points = [1]
         nqubits = 2
         p = ql.Program("basic", platf, nqubits, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel
         k = ql.Kernel("first_kernel", platf, nqubits, nqubits)

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -27,7 +27,7 @@ class Test_bugs(unittest.TestCase):
         config_fn = os.path.join(curdir, 'test_config_default.json')
         platf = ql.Platform("starmon", config_fn)
         p = ql.Program('test_bug', platf, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         k = ql.Kernel('kernel1', platf, num_qubits)
 
         qubit = 1
@@ -55,8 +55,8 @@ class Test_bugs(unittest.TestCase):
 
         p1 = ql.Program("order1_prog", platform, nqubits, nregs)
         p2 = ql.Program("order2_prog", platform, nqubits, nregs)
-        p1.set_sweep_points(sweep_points, len(sweep_points))
-        p2.set_sweep_points(sweep_points, len(sweep_points))
+        p1.set_sweep_points(sweep_points)
+        p2.set_sweep_points(sweep_points)
         k1 = ql.Kernel("aKernel", platform, nqubits, nregs)
         k2 = ql.Kernel("aKernel", platform, nqubits, nregs)
 
@@ -95,7 +95,7 @@ class Test_bugs(unittest.TestCase):
         nregs = 3
 
         p = ql.Program("statelessProgram", platform, nqubits, nregs)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         k = ql.Kernel("aKernel", platform, nqubits, nregs)
 
         k.prepz(0)

--- a/tests/test_cc_light.py
+++ b/tests/test_cc_light.py
@@ -39,7 +39,7 @@ class Test_basic(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -75,7 +75,7 @@ class Test_basic(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate the second kernel using both custom and default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -108,7 +108,7 @@ class Test_basic(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate the first kernel using default gates
         k = ql.Kernel('aKernel01', platform, num_qubits)
@@ -154,7 +154,7 @@ class Test_basic(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_smis_all_bundled', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 
@@ -188,7 +188,7 @@ class Test_basic(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -226,7 +226,7 @@ class Test_basic(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_smit_all_bundled', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -263,7 +263,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -289,7 +289,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -315,7 +315,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -341,7 +341,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -367,7 +367,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 
@@ -394,7 +394,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -422,7 +422,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -451,7 +451,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -474,7 +474,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -500,7 +500,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 7
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -530,7 +530,7 @@ class Test_advance(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # populate kernel using default gates
         k = ql.Kernel('aKernel', platform, num_qubits)
@@ -583,7 +583,7 @@ class Test_advance(unittest.TestCase):
             sweep_points = [1,2]
             num_qubits = 7
             p = ql.Program('test_ccl_buffers'+str(testNo), platform, num_qubits)
-            p.set_sweep_points(sweep_points, len(sweep_points))
+            p.set_sweep_points(sweep_points)
             k = ql.Kernel('aKernel', platform, num_qubits)
 
             for gate, qubits in testKernel:
@@ -624,7 +624,7 @@ class Test_advance(unittest.TestCase):
             sweep_points = [1,2]
             num_qubits = 7
             p = ql.Program('test_ccl_latencies'+str(testNo), platform, num_qubits)
-            p.set_sweep_points(sweep_points, len(sweep_points))
+            p.set_sweep_points(sweep_points)
             k = ql.Kernel('aKernel', platform, num_qubits)
 
             for gate, qubits in testKernel:

--- a/tests/test_cc_light_long_duration.py
+++ b/tests/test_cc_light_long_duration.py
@@ -39,7 +39,7 @@ class Test_CCL_long_duration(unittest.TestCase):
                 #  ['ry90', 'ry90']]
 
         # this should be implicit
-        p.set_sweep_points(np.arange(len(allXY), dtype=float), len(allXY))
+        p.set_sweep_points(np.arange(len(allXY), dtype=float))
         qubit_idx=0
         for i, xy in enumerate(allXY):
             k = ql.Kernel("AllXY_"+str(i), platf, platf.get_qubit_number())

--- a/tests/test_commutation.py
+++ b/tests/test_commutation.py
@@ -46,7 +46,7 @@ class Test_commutation(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("test_cnot_controlcommute", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -84,7 +84,7 @@ class Test_commutation(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("test_cnot_targetcommute", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -122,7 +122,7 @@ class Test_commutation(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("test_cz_anycommute", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -164,7 +164,7 @@ class Test_commutation(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("test_cnot_mixedcommute", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -20,7 +20,7 @@ class Test_Configuration(unittest.TestCase):
         platform  = ql.Platform('seven_qubits_chip', config_fn)
         p = ql.Program("aProgram", platform, platform.get_qubit_number())
         sweep_points = [1,2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, platform.get_qubit_number())
         k.gate('Rx180', [0])  # in the configuartion its name is rx180 q0
@@ -50,7 +50,7 @@ class Test_Configuration(unittest.TestCase):
         platform  = ql.Platform('seven_qubits_chip', config_fn)
         p = ql.Program("aProgram", platform, platform.get_qubit_number())
         sweep_points = [1,2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, platform.get_qubit_number())
         k.gate('rx180', [0])  # available
@@ -86,7 +86,7 @@ class Test_Configuration(unittest.TestCase):
         platform  = ql.Platform('seven_qubits_chip', config_fn)
         p = ql.Program("aProgram", platform, platform.get_qubit_number())
         sweep_points = [1,2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, platform.get_qubit_number())
 

--- a/tests/test_cqasm.py
+++ b/tests/test_cqasm.py
@@ -67,7 +67,7 @@ class Test_cqasm(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program('test_cqasm_default_gates', platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -114,7 +114,7 @@ class Test_cqasm(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program('test_cqasm_custom_gates', platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 

--- a/tests/test_dependence.py
+++ b/tests/test_dependence.py
@@ -42,7 +42,7 @@ class Test_dependence(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("independent", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -70,7 +70,7 @@ class Test_dependence(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("WAW", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -100,7 +100,7 @@ class Test_dependence(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("RAR", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -130,7 +130,7 @@ class Test_dependence(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("RAW", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -161,7 +161,7 @@ class Test_dependence(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("WAR", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -186,7 +186,7 @@ class Test_dependence(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("swap_single", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 
@@ -213,7 +213,7 @@ class Test_dependence(unittest.TestCase):
         sweep_points = [2]
 
         p = ql.Program("swap_multi", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
         p.add_kernel(k)
         p.compile()
 

--- a/tests/test_gate_decomposition.py
+++ b/tests/test_gate_decomposition.py
@@ -18,7 +18,7 @@ class Tester(unittest.TestCase):
         sweep_points = [1,2]
         num_qubits = 17
         p = ql.Program('aProgram', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -26,7 +26,7 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
 
         p = ql.Program('test_classical', platform, num_qubits, num_cregs)
         sweep_points = [1, 2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k1 = ql.Kernel('aKernel1', platform, num_qubits, num_cregs)
 
@@ -73,7 +73,7 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
 
         p = ql.Program('test_if', platform, num_qubits, num_cregs)
         sweep_points = [1, 2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k1 = ql.Kernel('aKernel1', platform, num_qubits, num_cregs)
         k2 = ql.Kernel('aKernel2', platform, num_qubits, num_cregs)
@@ -104,7 +104,7 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
 
         p = ql.Program('test_if_else', platform, num_qubits, num_cregs)
         sweep_points = [1, 2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k1 = ql.Kernel('aKernel1', platform, num_qubits, num_cregs)
         k2 = ql.Kernel('aKernel2', platform, num_qubits, num_cregs)
@@ -135,7 +135,7 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
 
         p = ql.Program('test_for', platform, num_qubits, num_cregs)
         sweep_points = [1, 2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k1 = ql.Kernel('aKernel1', platform, num_qubits, num_cregs)
         k2 = ql.Kernel('aKernel2', platform, num_qubits, num_cregs)
@@ -166,7 +166,7 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
 
         p = ql.Program('test_do_while', platform, num_qubits, num_cregs)
         sweep_points = [1, 2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k1 = ql.Kernel('aKernel1', platform, num_qubits, num_cregs)
         k2 = ql.Kernel('aKernel2', platform, num_qubits, num_cregs)
@@ -198,7 +198,7 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
         p = ql.Program('test_do_while_nested_for',
                        platform, num_qubits, num_cregs)
         sweep_points = [1, 2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         sp1 = ql.Program('subprogram1', platform, num_qubits, num_cregs)
         sp2 = ql.Program('subprogram2', platform, num_qubits, num_cregs)

--- a/tests/test_quantumsim.py
+++ b/tests/test_quantumsim.py
@@ -23,7 +23,7 @@ class Test_quantumsim(unittest.TestCase):
         num_qubits = 2
         p = ql.Program('aProgram', platform, num_qubits)
         sweep_points = [1, 2]
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # create a kernel
         k = ql.Kernel('aKernel', platform, num_qubits)

--- a/tests/test_qubits.py
+++ b/tests/test_qubits.py
@@ -35,7 +35,7 @@ class Test_qubits(unittest.TestCase):
         k.measure(0)
 
         p = ql.Program("1_qubit_program", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         p.add_kernel(k)  # add kernel to program
         p.compile()
@@ -58,7 +58,7 @@ class Test_qubits(unittest.TestCase):
         k.measure(2)
 
         p = ql.Program("2_qubit_program", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         p.add_kernel(k)  # add kernel to program
         p.compile()
@@ -81,7 +81,7 @@ class Test_qubits(unittest.TestCase):
         k.measure(2)
 
         p = ql.Program("3_qubit_program", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         p.add_kernel(k)  # add kernel to program
 

--- a/tests/test_standard_single_Q_experiments_CBox.py
+++ b/tests/test_standard_single_Q_experiments_CBox.py
@@ -29,7 +29,7 @@ class Test_single_qubit_seqs_CBox(unittest.TestCase):
                  ['rx180', 'i'], ['ry180', 'i'], ['rx90', 'rx90'],
                  ['ry90', 'ry90']]
          # this should be implicit
-        p.set_sweep_points(np.arange(len(allXY), dtype=float), len(allXY))
+        p.set_sweep_points(np.arange(len(allXY), dtype=float))
 
         for i, xy in enumerate(allXY):
             k = Kernel("allXY"+str(i), platform=platf, qubit_count=nqubits)
@@ -52,7 +52,7 @@ class Test_single_qubit_seqs_CBox(unittest.TestCase):
         # To prevent superslow workaround
         times = np.linspace(0, 60, 61)  # in ns
         # this should be implicit
-        p.set_sweep_points(times, len(times))
+        p.set_sweep_points(times)
         for tau in times:
             # this is an invalid kernel name (contains '.')
             # and will produce and invalid qasm

--- a/tests/test_std_experiments_CCL.py
+++ b/tests/test_std_experiments_CCL.py
@@ -51,7 +51,7 @@ class Test_single_qubit_seqs_CCL(unittest.TestCase):
                  ['rx180', 'i'], ['ry180', 'i'], ['rx90', 'rx90'],
                  ['ry90', 'ry90']]
          # this should be implicit
-        p.set_sweep_points(np.arange(len(allXY), dtype=float), len(allXY))
+        p.set_sweep_points(np.arange(len(allXY), dtype=float))
 
         for i, xy in enumerate(allXY):
             k = Kernel("allXY"+str(i), platf, 1)
@@ -74,7 +74,7 @@ class Test_single_qubit_seqs_CCL(unittest.TestCase):
         # To prevent superslow workaround
         times = np.linspace(0, 60, 61)  # in ns
         # this should be implicit
-        p.set_sweep_points(times, len(times))
+        p.set_sweep_points(times)
         for tau in times:
             # this is an invalid kernel name (contains '.')
             # and will produce and invalid qasm

--- a/tests/test_sweep_points.py
+++ b/tests/test_sweep_points.py
@@ -30,7 +30,7 @@ class Test_sweep_points(unittest.TestCase):
 
         # create a program
         p = ql.Program("aProgram", platf, nqubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         # add kernel to program
         p.add_kernel(k)
@@ -47,6 +47,26 @@ class Test_sweep_points(unittest.TestCase):
         # compare list in json with initial list of sweep_points
         matched = [(i, j) for i, j in zip(config['measurement_points'], sweep_points)]
         self.assertEqual(len(matched), len(sweep_points))
+
+    def test_no_sweep_points(self):
+        nqubits = 1
+
+        # create a kernel
+        k = ql.Kernel("aKernel", platf, nqubits)
+
+        # populate a kernel
+        k.prepz(0)
+        k.measure(0)
+
+        # create a program
+        p = ql.Program("aProgram", platf, nqubits)
+
+        # add kernel to program
+        p.add_kernel(k)
+
+        # compile
+        p.compile()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -27,7 +27,7 @@ class Test_wait(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_wait_simple', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 
@@ -49,7 +49,7 @@ class Test_wait(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_wait_parallel', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 
@@ -72,7 +72,7 @@ class Test_wait(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = 7
         p = ql.Program('test_wait_sweep', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         qubit_idx = 0
         waits = [20, 40, 60, 100, 200, 400, 800, 1000, 2000]
@@ -109,7 +109,7 @@ class Test_wait(unittest.TestCase):
         sweep_points = [1, 2]
         num_qubits = platform.get_qubit_number()
         p = ql.Program('test_wait_multi', platform, num_qubits)
-        p.set_sweep_points(sweep_points, len(sweep_points))
+        p.set_sweep_points(sweep_points)
 
         k = ql.Kernel('aKernel', platform, num_qubits)
 


### PR DESCRIPTION
Sweep point array is no more required as discussed in issue #76. Deprecated warnings are added to  `set_sweep_points()` and `get_sweep_points()` API.

The following (already deprecated API) has been removed:

`void set_sweep_points(std::vector<float> sweep_points, size_t num_sweep_points)`

Documentation is updated and tests are added in test_sweep_points.py.