### PR TITLE
fixed duplicate kernel name issue

### DIFF
--- a/src/program.cc
+++ b/src/program.cc
@@ -97,6 +97,13 @@ void quantum_program::add(ql::quantum_kernel &k)
         }
     }
 
+    for (auto kernel : kernels)
+    {
+        if(kernel.name == k.name)
+        {
+            FATAL("Cannot add kernel. Duplicate kernel name: " << k.name);
+        }
+    }
     // if sane, now add kernel to list of kernels
     kernels.push_back(k);
 }

--- a/tests/test_Kernel.py
+++ b/tests/test_Kernel.py
@@ -111,6 +111,32 @@ class Test_kernel(unittest.TestCase):
 
         p.compile()
 
+    def test_duplicate_kernel_name(self):
+        nqubits = 3
+
+        p = ql.Program("aProgram", platf, nqubits)
+        k1 = ql.Kernel("aKernel1", platf, nqubits)
+        k2 = ql.Kernel("aKernel2", platf, nqubits)
+        k3 = ql.Kernel("aKernel1", platf, nqubits)
+
+        k1.gate('x', [0])
+        k2.gate('x', [0])
+        k3.gate('x', [0])
+
+        # add the kernel to the program
+        p.add_kernel(k1)
+        p.add_kernel(k2)
+
+        # following call to add_kernel should fail as k3 has duplicate name
+        try:
+            p.add_kernel(k3)
+            raise
+        except:
+            pass
+
+        # compile the program
+        p.compile()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adding duplicate kernel names now raise an exception. `test_duplicate_kernel_name()` in `test_Kernel()` tests it. closes https://github.com/QE-Lab/OpenQL/issues/236.