### PR TITLE
fix jenkins build errors and test error

### DIFF
--- a/Jenkinsfile-master
+++ b/Jenkinsfile-master
@@ -42,9 +42,10 @@ pipeline {
                     sh 'python3 -m venv env'
                     sh '''
                             . ./env/bin/activate &&
+                            pip3 install --upgrade setuptools
                             pip3 --cache-dir /var/pip_cache install pytest numpy &&
                             pip3 install -e . &&
-                            python3 libqasm/qasm_flex_bison/setup.py install
+                            python3 libqasm/qasm_flex_bison/setup.py install &&
                             pip3 install eQASM_Assembler/qisa-as
                        '''
                 }
@@ -60,7 +61,7 @@ pipeline {
                 dir(PERSIST_WORKSPACE) {
                     sh '''
                             . ./env/bin/activate &&
-                            pytest --ignore=eQASM_Assembler/
+                            pytest --ignore=eQASM_Assembler/ --ignore=libqasm/
                        '''
                 }
             }

--- a/Jenkinsfile-v2.2.0
+++ b/Jenkinsfile-v2.2.0
@@ -42,9 +42,10 @@ pipeline {
                     sh 'python3 -m venv env'
                     sh '''
                             . ./env/bin/activate &&
+                            pip3 install --upgrade setuptools
                             pip3 --cache-dir /var/pip_cache install pytest numpy &&
                             pip3 install -e . &&
-                            python3 libqasm/qasm_flex_bison/setup.py install
+                            python3 libqasm/qasm_flex_bison/setup.py install &&
                             pip3 install eQASM_Assembler/qisa-as
                        '''
                 }
@@ -60,7 +61,7 @@ pipeline {
                 dir(PERSIST_WORKSPACE) {
                     sh '''
                             . ./env/bin/activate &&
-                            pytest --ignore=eQASM_Assembler/
+                            pytest --ignore=eQASM_Assembler/ --ignore=libqasm/
                        '''
                 }
             }

--- a/tests/test_QASM_assembler_present.py
+++ b/tests/test_QASM_assembler_present.py
@@ -17,7 +17,8 @@ except:
 
 def assemble(QASM_fn):
     if assembler_present:
-        lq1 = lq(qasm_file_path=QASM_fn)
+        lq1 = lq()
+        lq1.parse_file(qasm_file_path=QASM_fn)
         failure = lq1.getParseResult()
         if failure:
             # TODO does libQASM tracks last error


### PR DESCRIPTION
* Fix Jenkins build errors
* In Jenkins exclude libqasm in search for pytest test cases for testing OpenQL
* Fix in test_QASM_assembler_present. Interface-change for parsing a libqasm file