### PR TITLE
pypi wheel upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ env
 *.cache
 swig/openql.py
 swig/openql/openql.py
+swig/qutechtools.egg-info
 
 # Test files
 test_output

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ env
 *.cache
 swig/openql.py
 swig/openql/openql.py
-swig/qutechtools.egg-info
+swig/qutechopenql.egg-info
 
 # Test files
 test_output

--- a/cleanme.py
+++ b/cleanme.py
@@ -2,7 +2,8 @@
 import os
 import shutil
 
-dirs = ['build', 'cbuild', 'dist', 'openql.egg-info', ]
+dirs = ['build', 'cbuild', 'dist', 'openql.egg-info',
+		'swig/qutechtools.egg-info', 'swig/openql.egg-info']
 files = ['']
 
 for dir in dirs:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,9 @@
 Installation
 ============
 
-OpenQL is supported on Linux, Windows and OSX. OpenQL can be installed on these platforms as a pre-built package as well as can be compiled from sources.
+OpenQL is supported on Linux, Windows and OSX. OpenQL can be installed on
+these platforms as a pre-built package as well as can be compiled from
+sources.
 
 - Pre-built package
 	- python package using pip
@@ -17,20 +19,23 @@ Installing Pre-built package
 
 Pre-built packges are avialable for openql.
 
+
 Pre-built Wheels
 ^^^^^^^^^^^^^^^^
 
-This is perhaps the most easiest way to get OpenQL running on your machine. Prebuilt OpenQL wheels are available for 64-bit Windows, Linux and OSX. These wheels are available for Python 3.5, 3.6 and 3.7. OpenQL can be installed by using one of these pre-built wheels for the specific python version and platform at hand, by the command:
+This is perhaps the most easiest way to get OpenQL running on your machine.
+Pre-built OpenQL wheels are available for 64-bit Windows, Linux and OSX. These
+wheels are available for Python 3.5, 3.6 and 3.7. OpenQL can be installed by
+the command:
 
 ::
 
-    pip install <openql*.whl>
+    pip install qutechtools
 
-For example, on 64-bit linux,
 
-::
+.. note::
 
-    pip install https://github.com/QE-Lab/OpenQL/releases/download/0.8.0/openql-0.8.0-cp35-cp35m-linux_x86_64.whl
+    ``python`` refers to Python 3 and ``pip`` refers to Pip 3, corresponding to Python version 3.5, 3.6 or 3.7.
 
 
 Conda package
@@ -79,10 +84,6 @@ The following packges are required to compile OpenQL from sources:
 - [Optional] Graphviz Dot utility to convert graphs from dot to pdf, png etc
 - [Optional] XDot to visualize generated graphs in dot format
 
-
-.. note::
-
-    In all the following instructions, python refers to Python 3 and pip refers to Pip 3.
 
 Notes for Windows Users
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,7 +30,7 @@ the command:
 
 ::
 
-    pip install qutechtools
+    pip install qutechopenql
 
 
 .. note::

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ try:
 except ImportError:
     bdist_wheel = None
 
-setup(name='openql',
+setup(name='qutechtools',
       version=get_version(),
       description='OpenQL Python Package',
       long_description=read('README.md'),

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ try:
 except ImportError:
     bdist_wheel = None
 
-setup(name='qutechtools',
+setup(name='qutechopenql',
       version=get_version(),
       description='OpenQL Python Package',
       long_description=read('README.md'),


### PR DESCRIPTION
openql wheels are now available on PYPI. openql can now be installed by

`pip install qutechtools`

updated sphinx documentation

closes issue https://github.com/QE-Lab/OpenQL/issues/260