### PR TITLE
CPP example compilation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -161,15 +161,10 @@ Existing tests and programs can be compiled on Linux OS by the following command
     make       # compiles the source code into the current directory. 
 
 
-To execute the given examples/test, go to e.g., `OpenQL/cbuild/examples` and execute one of the files e.g.,  `./simple`. The output will be saved to the output directory next to the file.
+To execute the given examples/test, go to e.g., ```OpenQL/cbuild/examples``` and execute one of the files e.g.,  ```./simple```. The output will be saved to the output directory next to the file.
 
-If one wants to compile and run a single file without adding it to CMakeLists.txt, e.g., `example.cc`, the following instructions should be followed:
+If one wants to compile and run a single file without adding it to CMakeLists.txt, e.g., ```example.cc```, he can use the standalone example provided in ```examples/cpp-standalone-example``` directory.
 
-::
-
-    mkdir output           # create an output directory if it does not exist
-    g++ -std=c++11 example.cc -o example.exe -I OpenQL/   # compile the file
-    ./example.exe                                         # execute the file
 
 
 Windows

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,23 +1,6 @@
 INCLUDE_DIRECTORIES(
-  ${PROJECT_SOURCE_DIR}/src
-  ${PROJECT_SOURCE_DIR}/examples
-  ${PROJECT_SOURCE_DIR}/tests
+  ../swig
 )
-
-# Uncomment the programs which you want to compile
-# you can also add your own programs on the similar lines
-
-# ADD_EXECUTABLE(simple simple.cc )
-# TARGET_LINK_LIBRARIES(simple ${LEMON_LIBRARIES} )
-
-# ADD_EXECUTABLE(rb_single rb_single.cc )
-# TARGET_LINK_LIBRARIES(rb_single ${LEMON_LIBRARIES} )
-
-# ADD_EXECUTABLE(randomized_benchmarking randomized_benchmarking.cc )
-# TARGET_LINK_LIBRARIES(randomized_benchmarking ${LEMON_LIBRARIES} )
-
-# ADD_EXECUTABLE(multi_qubits_randomized_benchmarking multi_qubits_randomized_benchmarking.cc )
-# TARGET_LINK_LIBRARIES(multi_qubits_randomized_benchmarking ${LEMON_LIBRARIES} )
 
 # create output directory for test outputs
 ADD_CUSTOM_TARGET(examples-output-directory ALL
@@ -32,3 +15,18 @@ CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/tests/hardware_config_cc_light.json
 
 CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/tests/hardware_config_qx.json
     hardware_config_qx.json COPYONLY)
+
+# Uncomment the programs which you want to compile
+# you can also add your own programs on the similar lines
+
+ADD_EXECUTABLE(simple simple.cc )
+TARGET_LINK_LIBRARIES(simple ${LEMON_LIBRARIES} ql)
+
+# ADD_EXECUTABLE(rb_single rb_single.cc )
+# TARGET_LINK_LIBRARIES(rb_single ${LEMON_LIBRARIES} )
+
+# ADD_EXECUTABLE(randomized_benchmarking randomized_benchmarking.cc )
+# TARGET_LINK_LIBRARIES(randomized_benchmarking ${LEMON_LIBRARIES} )
+
+# ADD_EXECUTABLE(multi_qubits_randomized_benchmarking multi_qubits_randomized_benchmarking.cc )
+# TARGET_LINK_LIBRARIES(multi_qubits_randomized_benchmarking ${LEMON_LIBRARIES} )

--- a/examples/cpp-standalone-example/CMakeLists.txt
+++ b/examples/cpp-standalone-example/CMakeLists.txt
@@ -1,0 +1,75 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0)
+CMAKE_POLICY(SET CMP0054 NEW)
+
+PROJECT(EXAMPLE)
+
+# TODO: update the path to openql and _openql.so according to your setup 
+SET(OPENQL_ROOT /data/repos/quantum_repos/openql)
+SET(OPENQL_LIB "${OPENQL_ROOT}/cbuild/swig/_openql.so")
+
+SET(CMAKE_BUILD_TYPE Release CACHE STRING
+    "Type of build (None Debug Release RelWithDebInfo MinSizeRel)" FORCE)
+SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+    "RelWithDebInfo" "MinSizeRel")
+
+SET(CMAKE_MODULE_PATH ${OPENQL_ROOT}/cmake)
+
+FIND_PATH(LEMON_SOURCE_ROOT_DIR CMakeLists.txt
+  PATHS ${OPENQL_ROOT}/lemon ${OPENQL_ROOT}/deps/lemon
+  NO_DEFAULT_PATH
+  DOC "Location of LEMON source as a CMAKE subproject")
+
+IF(EXISTS ${LEMON_SOURCE_ROOT_DIR})
+  ADD_SUBDIRECTORY(${LEMON_SOURCE_ROOT_DIR} deps/lemon)
+  SET(LEMON_INCLUDE_DIRS
+    ${LEMON_SOURCE_ROOT_DIR}
+    ${PROJECT_BINARY_DIR}/deps/lemon
+  )
+  SET(LEMON_LIBRARIES lemon)
+  UNSET(LEMON_ROOT_DIR CACHE)
+  UNSET(LEMON_DIR CACHE)
+  UNSET(LEMON_INCLUDE_DIR CACHE)
+  UNSET(LEMON_LIBRARY CACHE)
+ELSE()
+  FIND_PACKAGE(LEMON QUIET NO_MODULE)
+  FIND_PACKAGE(LEMON REQUIRED)
+ENDIF()
+
+
+SET(CLI11_INCLUDE_DIRS
+  "${OPENQL_ROOT}/deps/CLI11/include"
+)
+
+
+## These are the include directories used by the compiler.
+INCLUDE_DIRECTORIES(
+  ${LEMON_INCLUDE_DIRS}
+  ${CLI11_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}
+  ${OPENQL_ROOT}/src
+  ${OPENQL_ROOT}/swig
+)
+
+IF(CMAKE_COMPILER_IS_GNUCXX)
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -Wfatal-errors -ggdb")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++11 -Wall -Wfatal-errors -ggdb")
+ENDIF(CMAKE_COMPILER_IS_GNUCXX)
+
+IF(MSVC)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++11 /MP /D_USE_MATH_DEFINES")
+ENDIF(MSVC)
+
+IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -Wfatal-errors -ggdb")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -std=c++11 -Wall -Wfatal-errors -Wno-unused-local-typedef -ggdb")
+ENDIF("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+
+
+ADD_LIBRARY(openql_lib SHARED IMPORTED)
+SET_TARGET_PROPERTIES(openql_lib PROPERTIES
+  IMPORTED_LOCATION ${OPENQL_LIB}
+)
+
+# TODO: change the name of .cc file which you want compile if not example.cc
+ADD_EXECUTABLE(example example.cc )
+TARGET_LINK_LIBRARIES(example ${LEMON_LIBRARIES} openql_lib)

--- a/examples/cpp-standalone-example/example.cc
+++ b/examples/cpp-standalone-example/example.cc
@@ -4,7 +4,8 @@
 int main(int argc, char ** argv)
 {
   // create platform
-  ql::quantum_platform platf("seven_qubits_chip", "hardware_config_cc_light.json");
+  ql::quantum_platform platf("seven_qubits_chip",
+    "/data/repos/quantum_repos/openql/tests/hardware_config_cc_light.json");
 
   // create program
   ql::quantum_program prog("aProgram", platf, 2);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ INCLUDE_DIRECTORIES(
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_SOURCE_DIR}/examples
   ${PROJECT_SOURCE_DIR}/tests
+  ${PROJECT_SOURCE_DIR}/swig
 )
 
 # here are the C++ tests which will be compiled from this directory
@@ -31,3 +32,5 @@ CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/tests/hardware_config_qx.json
 CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/tests/cc/test_cfg_cc.json
 	test_cfg_cc.json COPYONLY)
 
+ADD_EXECUTABLE(test_mapper test_mapper.cc )
+TARGET_LINK_LIBRARIES(test_mapper ${LEMON_LIBRARIES} ql)

--- a/tests/test_mapper.cc
+++ b/tests/test_mapper.cc
@@ -3,6 +3,9 @@
 
 int main(int argc, char ** argv)
 {
+  ql::utils::logger::set_log_level("LOG_NOTHING");
+  ql::options::set("write_qasm_files", "yes");
+
   // create platform
   ql::quantum_platform platf("seven_qubits_chip", "hardware_config_cc_light.json");
 

--- a/tests/test_mapper.cc
+++ b/tests/test_mapper.cc
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <openql_i.h>
+
+int main(int argc, char ** argv)
+{
+  // create platform
+  ql::quantum_platform platf("seven_qubits_chip", "hardware_config_cc_light.json");
+
+  // create program
+  ql::quantum_program prog("aProgram", platf, 2);
+
+  // create kernel
+  ql::quantum_kernel k("aKernel", platf, 2);
+
+  k.gate("prepz", 0);
+  k.gate("prepz", 1);
+  k.gate("x", 0);
+  k.gate("y", 1);
+  k.measure(0);
+  k.measure(1);
+
+  // add kernel to program
+  prog.add(k);
+
+  // compile the program
+  prog.compile();
+
+  return 0;
+}


### PR DESCRIPTION
updated cmake files to sucessfully build cpp example **simple.cc**.

also added a standalone example to compile cpp examples outside openql directory, if required.

This should fix https://github.com/QE-Lab/OpenQL/issues/245.