### PR TITLE
Change the name of the generated quantumsim scripts.

### DIFF
--- a/src/arch/cc_light/cc_light_eqasm_compiler.h
+++ b/src/arch/cc_light/cc_light_eqasm_compiler.h
@@ -1727,7 +1727,7 @@ private:
     {
         IOUT("Writing scheduled Quantumsim program");
         ofstream fout;
-        string qfname( ql::options::get("output_dir") + "/" + prog_name + "_quantumsim_" + suffix + ".py");
+        string qfname( ql::options::get("output_dir") + "/" + "quantumsim_" + prog_name + "_" + suffix + ".py");
         DOUT("Writing scheduled Quantumsim program to " << qfname);
         IOUT("Writing scheduled Quantumsim program to " << qfname);
         fout.open( qfname, ios::binary);

--- a/src/qsoverlay.h
+++ b/src/qsoverlay.h
@@ -23,7 +23,7 @@ void write_qsoverlay_program( std::string prog_name, size_t num_qubits,
 
         IOUT("Writing scheduled QSoverlay program");
         ofstream fout;
-        string qfname( ql::options::get("output_dir") + "/" + prog_name + "_quantumsim_" + suffix + ".py");
+        string qfname( ql::options::get("output_dir") + "/" + "quantumsim_" + prog_name + "_" + suffix + ".py");
         DOUT("Writing scheduled QSoverlay program " << qfname);
         IOUT("Writing scheduled QSoverlay program " << qfname);
         fout.open( qfname, ios::binary);


### PR DESCRIPTION
Reversed the order of test_file_name + _quantumsim_ to quantumsim_ + test_file_name
to avoid generated quantumsim scripts being included in compiler regression tests.
Failing to do so will crash any subsequent compiler tests if quantumsim
is not available as a module on the system.

Files modified:
	* src/arch/cc_light/cc_light_eqasm_compiler.h
	* src/qsoverlay.h