### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,12 @@ ENDIF()
 
 PROJECT(OPENQL)
 
+IF (NOT CMAKE_BUILD_TYPE)
 SET(CMAKE_BUILD_TYPE Release CACHE STRING
     "Type of build (None Debug Release RelWithDebInfo MinSizeRel)" FORCE)
 SET_PROPERTY(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
     "RelWithDebInfo" "MinSizeRel")
+ENDIF()
 
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
This commit prevents that OpenQL overwrites the settings of the build type when used as sub-project in another project.