### PR TITLE
Fix documentation API generation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,15 +16,8 @@ formats:
 python:
   version: 3.7
   install:
-#    - requirements: docs/requirements-docs.txt
-    - method: pip
+    - method: setuptools
       path: .
-#      extra_requirements:
-#        - sphinx>=1.6
-#        - sphinx-autodoc-typehints==1.5.0
-#        - m2r
-#    - method: setuptools
-#      path: .
 
 submodules:
   include: all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,8 +19,12 @@ python:
     - requirements: docs/requirements-docs.txt
     - method: pip
       path: .
-    - method: setuptools
-      path: .
+      extra_requirements:
+        - sphinx>=1.6
+        - sphinx-autodoc-typehints==1.5.0
+        - m2r
+#    - method: setuptools
+#      path: .
 
 submodules:
   include: all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,13 +16,13 @@ formats:
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements-docs.txt
+#    - requirements: docs/requirements-docs.txt
     - method: pip
       path: .
-      extra_requirements:
-        - sphinx>=1.6
-        - sphinx-autodoc-typehints==1.5.0
-        - m2r
+#      extra_requirements:
+#        - sphinx>=1.6
+#        - sphinx-autodoc-typehints==1.5.0
+#        - m2r
 #    - method: setuptools
 #      path: .
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,31 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+conda:
+  environment: docs/.conda.yml
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements-docs.txt
+    - method: pip
+      path: .
+    - method: setuptools
+      path: .
+
+submodules:
+  include: all
+  recursive: true
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -8,6 +8,6 @@ dependencies:
     - flex=2.6
     - pip
     - pip:
-        - sphinx-autodoc-typehints=1.5.0
+        - sphinx-autodoc-typehints==1.5.0
         - m2r
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -5,4 +5,9 @@ dependencies:
     - cmake
     - bison=3.0
     - flex=2.6
+    - pip
+    - pip:
+        - sphinx>=1.6
+        - sphinx-autodoc-typehints==1.5.0
+        - m2r
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -7,6 +7,6 @@ dependencies:
     - flex=2.6
     - pip
     - pip:
-        - "sphinx>=1.8,<2"
+        - "python3-sphinx<2"
         - m2r
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -1,0 +1,8 @@
+dependencies:
+    - python=3.7
+    - setuptools
+    - swig
+    - cmake
+    - bison=3.0
+    - flex=2.6
+

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -1,5 +1,6 @@
 dependencies:
     - python=3.7
+    - sphinx==1.8.5
     - setuptools
     - swig
     - cmake

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -1,6 +1,5 @@
 dependencies:
     - python=3.7
-    - "sphinx>=1.8,<2"
     - setuptools
     - swig
     - cmake
@@ -8,5 +7,6 @@ dependencies:
     - flex=2.6
     - pip
     - pip:
+        - "sphinx>=1.8,<2"
         - m2r
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -7,7 +7,7 @@ dependencies:
     - flex=2.6
     - pip
     - pip:
-        - sphinx>=1.6
+        - sphinx<2
         - sphinx-autodoc-typehints==1.5.0
         - m2r
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -1,5 +1,6 @@
 dependencies:
     - python=3.7
+    - sphinx=1.8.5 
     - setuptools
     - swig
     - cmake
@@ -7,7 +8,6 @@ dependencies:
     - flex=2.6
     - pip
     - pip:
-        - sphinx<2
-        - sphinx-autodoc-typehints==1.5.0
+        - sphinx-autodoc-typehints=1.5.0
         - m2r
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -1,6 +1,5 @@
 dependencies:
     - python=3.7
-    - sphinx=1.8.5 
     - setuptools
     - swig
     - cmake
@@ -8,6 +7,5 @@ dependencies:
     - flex=2.6
     - pip
     - pip:
-        - sphinx-autodoc-typehints==1.5.0
         - m2r
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -7,5 +7,5 @@ dependencies:
     - flex=2.6
     - pip
     - pip:
-        - -r file:docs/requirements-docs.txt
+        - -r file:requirements-docs.txt
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -7,6 +7,5 @@ dependencies:
     - flex=2.6
     - pip
     - pip:
-        - "python3-sphinx<2"
-        - m2r
+        - -r file:docs/requirements-docs.txt
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -1,6 +1,6 @@
 dependencies:
     - python=3.7
-    - sphinx==1.8.5
+    - "sphinx>=1.8,<2"
     - setuptools
     - swig
     - cmake

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,4 +1,0 @@
-sphinx>=1.6
-sphinx-autodoc-typehints==1.5.0
-m2r
-cmake

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,4 @@
+sphinx>=1.6
+sphinx-autodoc-typehints==1.5.0
+m2r
+cmake

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,3 +1,3 @@
-sphinx>=1.6
+sphinx<2
 sphinx-autodoc-typehints==1.5.0
 m2r

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,3 @@
+sphinx>=1.6
+sphinx-autodoc-typehints==1.5.0
+m2r

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,0 @@
-sphinx>=1.6
-sphinx-autodoc-typehints
-m2r
-cmake


### PR DESCRIPTION
This PR enables again the build (broken after the addition of libqasm dependencies which needed C packages) of openql in readthedocs(RTD) by switching to the conda environment to be able to install the required C dependencies (flex and bison), that was not possible in the default virtualenv RTD environment. 