### PR TITLE
Correct name glpk for conda-RTD

### DIFF
--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -6,7 +6,6 @@ dependencies:
     - bison=3.0
     - flex=2.6
     - pip
-    - glpk-dev
     - pip:
         - -r file:requirements-docs.txt
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -6,7 +6,7 @@ dependencies:
     - bison=3.0
     - flex=2.6
     - pip
-    - libglpk-dev
+    - glpk-dev
     - pip:
         - -r file:requirements-docs.txt
 

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -5,6 +5,7 @@ dependencies:
     - cmake
     - bison=3.0
     - flex=2.6
+    - glpk
     - pip
     - pip:
         - -r file:requirements-docs.txt

--- a/src/mapper.h
+++ b/src/mapper.h
@@ -1,4 +1,4 @@
-//#define INITIALPLACE 1
+#define INITIALPLACE 1
 // commenting out the #define INITIALPLACE above, takes out all what's needed for initial placement
 /**
  * @file   mapper.h

--- a/src/mapper.h
+++ b/src/mapper.h
@@ -1,4 +1,4 @@
-#define INITIALPLACE 1
+//#define INITIALPLACE 1
 // commenting out the #define INITIALPLACE above, takes out all what's needed for initial placement
 /**
  * @file   mapper.h


### PR DESCRIPTION
Fix wrong name for conda install in RTD, i.e. glpk instead of libglpk-dev