### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,11 @@ SET(CLI11_INCLUDE_DIRS
 )
 
 SET(EIGEN_INCLUDE_DIRS
-  "${CMAKE_SOURCE_DIR}/deps/eigen/Eigen"
+  "${PROJECT_SOURCE_DIR}/deps/eigen/Eigen"
 )
 
 SET(EIGEN_UNSUPPORTED_INCLUDE_DIRS
-  "${CMAKE_SOURCE_DIR}/deps/eigen/unsupported"
+  "${PROJECT_SOURCE_DIR}/deps/eigen/unsupported"
 )
 
 OPTION(LIBQASM_COMPAT "" ON)


### PR DESCRIPTION
Using CMAKE_SOURCE_DIR does not work correctly if OpenQL is used as subproject within another project. Either use CMAKE_CURRENT_SOURCE_DIR or (better choice) PROJECT_SOURCE_DIR.