### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,6 @@ setup(
     long_description_content_type = 'text/markdown',
     author='QuTech, TU Delft',
     url='https://github.com/QE-Lab/OpenQL',
-    license=read('LICENSE'),
 
     classifiers = [
         'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
The [license](https://packaging.python.org/guides/distributing-packages-using-setuptools/#license) field is only to be used when there is no trove classifier for the license (there is, and it's already in there), and if used, [must be a single line](https://docs.python.org/3/distutils/setupscript.html#additional-meta-data) (note that short string means single line, max 200 characters). The wheel metadata is horribly broken at the moment, as evidenced by the [project page](https://pypi.org/project/qutechopenql) right now. Note the description and platform tags, and the actual description being interpreted as a code block. this is not what it should be looking like.