### PR TITLE
Rename .qasm output products to be backward compatible

### DIFF
--- a/src/passes.cc
+++ b/src/passes.cc
@@ -261,7 +261,7 @@ void WriterPass::runOnProgram(ql::quantum_program *program)
     //ql::report_init(program, program->platform);
     
     // writer pass of the initial qasm file (program.qasm)
-    ql::report_qasm(program, program->platform, "out", getPassName());
+    ql::write_qasm(program, program->platform, getPassName());
     
 //     if (getPassName() != "initialqasmwriter" && getPassName() != "scheduledqasmwriter")
 //     { ///@note-rn: temoporary hack to make the writer pass for those 2 configurations soft (i.e., do not delete the subcircuits) so that it does not require a reader pass after it!. This is needed until we fix the synchronization between hardware configuration files and openql tests. Until then a Reader pass would be needed after a hard Write pass. However, a Reader pass will make some unit tests to fail due to a mismatch between the instructions in the tests (i.e., prepz) and included/defined in the hardware config files CONFLICTING with the prepz instr not being available in libQASM.

--- a/tests/test_barrier.py
+++ b/tests/test_barrier.py
@@ -120,7 +120,7 @@ class Test_barrier(unittest.TestCase):
         p.compile()
 
 
-        QASM_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        QASM_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         gold_fn = rootDir + '/golden/test_barrier_all.qasm'
         self.assertTrue(file_compare(QASM_fn, gold_fn))
 
@@ -165,7 +165,7 @@ class Test_barrier(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
 
-        QASM_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        QASM_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         gold_fn = rootDir + '/golden/test_barrier_all.qasm'
         self.assertTrue(file_compare(QASM_fn, gold_fn))
 
@@ -210,7 +210,7 @@ class Test_barrier(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
 
-        QASM_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        QASM_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         gold_fn = rootDir + '/golden/test_barrier_all.qasm'
         self.assertTrue(file_compare(QASM_fn, gold_fn))
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -54,8 +54,8 @@ class Test_basic(unittest.TestCase):
         
         # load qasm
         qasm_files = []
-        qasm_files.append(os.path.join(output_dir, 'basic_initialqasmwriter_out.qasm'))
-        qasm_files.append(os.path.join(output_dir, 'basic_scheduledqasmwriter_out.qasm'))
+        qasm_files.append(os.path.join(output_dir, 'basic.qasm'))
+        qasm_files.append(os.path.join(output_dir, 'basic_scheduled.qasm'))
 
         for qasm_file in qasm_files:
             print('assembling: {}'.format(qasm_file))

--- a/tests/test_commutation.py
+++ b/tests/test_commutation.py
@@ -52,7 +52,7 @@ class Test_commutation(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/'+ p.name + '_scheduled.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
     def test_cnot_targetcommute(self):
@@ -90,7 +90,7 @@ class Test_commutation(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/'+ p.name + '_scheduled.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
     def test_cz_anycommute(self):
@@ -128,7 +128,7 @@ class Test_commutation(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/'+ p.name + '_scheduled.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
     def test_cnot_mixedcommute(self):
@@ -170,7 +170,7 @@ class Test_commutation(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/'+ p.name + '_scheduled.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
 if __name__ == '__main__':

--- a/tests/test_conjugate.py
+++ b/tests/test_conjugate.py
@@ -52,7 +52,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_conjugate.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'.qasm')
         self.assertTrue(file_compare(qasm_fn, gold_fn))
 
 

--- a/tests/test_cqasm.py
+++ b/tests/test_cqasm.py
@@ -73,8 +73,8 @@ class Test_cqasm(unittest.TestCase):
         p.compile()
 
         qasm_files = []
-        qasm_files.append(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
-        qasm_files.append(os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm'))
+        qasm_files.append(os.path.join(output_dir, p.name+'.qasm'))
+        qasm_files.append(os.path.join(output_dir, p.name+'_scheduled.qasm'))
 
         for qasm_file in qasm_files:
             # print('assembling: {}'.format(qasm_file))
@@ -120,8 +120,8 @@ class Test_cqasm(unittest.TestCase):
         p.compile()
 
         qasm_files = []
-        qasm_files.append(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
-        qasm_files.append(os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm'))
+        qasm_files.append(os.path.join(output_dir, p.name+'.qasm'))
+        qasm_files.append(os.path.join(output_dir, p.name+'_scheduled.qasm'))
 
         for qasm_file in qasm_files:
             print('assembling: {}'.format(qasm_file))

--- a/tests/test_dependence.py
+++ b/tests/test_dependence.py
@@ -50,7 +50,7 @@ class Test_dependence(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_independence.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
 
@@ -79,7 +79,7 @@ class Test_dependence(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_WAW_ASAP.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
 
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
@@ -110,7 +110,7 @@ class Test_dependence(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_RAR_Control_ASAP.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
 
@@ -141,7 +141,7 @@ class Test_dependence(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_RAW_ASAP.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
 
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
@@ -173,7 +173,7 @@ class Test_dependence(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_WAR_ASAP.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
 
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
@@ -199,7 +199,7 @@ class Test_dependence(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_swap_single_ASAP.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
 
@@ -227,7 +227,7 @@ class Test_dependence(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_swap_multi_ASAP.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_scheduledqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'_scheduled.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
 

--- a/tests/test_qubits.py
+++ b/tests/test_qubits.py
@@ -43,7 +43,7 @@ class Test_qubits(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_1_qubit.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
     def test_2_qubit(self):
@@ -67,7 +67,7 @@ class Test_qubits(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_2_qubit.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
     def test_3_qubit(self):
@@ -93,7 +93,7 @@ class Test_qubits(unittest.TestCase):
         p.compile()
 
         gold_fn = rootDir + '/golden/test_3_qubit.qasm'
-        qasm_fn = os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm')
+        qasm_fn = os.path.join(output_dir, p.name+'.qasm')
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
 if __name__ == '__main__':

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -64,7 +64,7 @@ class Test_skip(unittest.TestCase):
         prog.compile()
 
         GOLD_fn = os.path.join(rootDir, 'golden', prog.name + '_scheduled.qasm')
-        QASM_fn = os.path.join(output_dir, prog.name+'_scheduledqasmwriter_out.qasm')
+        QASM_fn = os.path.join(output_dir, prog.name+'_scheduled.qasm')
 
         assemble(QASM_fn)
         self.assertTrue(file_compare(QASM_fn, GOLD_fn))

--- a/tests/test_unitary.py
+++ b/tests/test_unitary.py
@@ -139,7 +139,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
 
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         self.assertAlmostEqual(0.5*(helper_prob(matrix[0])+helper_prob(matrix[1])), helper_regex(c0)[0], 5)
@@ -161,7 +161,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
         
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         self.assertAlmostEqual(helper_prob(matrix[0]), helper_regex(c0)[0], 5)
@@ -183,7 +183,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
         
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         self.assertAlmostEqual(helper_prob(matrix[0]), helper_regex(c0)[0], 5)
@@ -207,7 +207,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
         
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 		#HZH = X, so the result should be |0> + |1>
@@ -239,7 +239,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
         
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -274,7 +274,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
         
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -330,7 +330,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.compile()
 
 
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -357,7 +357,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.compile()
 
 
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -385,7 +385,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
         
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         self.assertAlmostEqual(helper_prob(matrix[0]), helper_regex(c0)[0], 5)
@@ -415,7 +415,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
 
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         self.assertAlmostEqual(helper_prob(matrix[0]), helper_regex(c0)[0], 5)
@@ -450,7 +450,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
 
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         
@@ -488,7 +488,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.add_kernel(k)
         p.compile()
 
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         
@@ -525,7 +525,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         
@@ -561,7 +561,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         
@@ -599,7 +599,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         
@@ -661,7 +661,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         
@@ -731,7 +731,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         
@@ -799,7 +799,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -887,7 +887,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -1130,7 +1130,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         
@@ -1194,7 +1194,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
         
@@ -1234,7 +1234,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -1264,7 +1264,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -1290,7 +1290,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -1317,7 +1317,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -1354,7 +1354,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -1392,7 +1392,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -1432,7 +1432,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 
@@ -1480,7 +1480,7 @@ class Test_conjugated_kernel(unittest.TestCase):
 
         p.add_kernel(k)
         p.compile()
-        qx.set(os.path.join(output_dir, p.name+'_initialqasmwriter_out.qasm'))
+        qx.set(os.path.join(output_dir, p.name+'.qasm'))
         qx.execute()
         c0 = qx.get_state()
 


### PR DESCRIPTION
As per Hans' instructions over e-mail. Effective changes:

 - `<program>_initialqasmwriter_out.qasm` becomes `<program>.qasm` (as expected by the examples);
 - `<program>_scheduledqasmwriter_out.qasm` becomes `<program>_scheduled.qasm`.

Closes #347.