### PR TITLE
Add stack trace to ql::exception message

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "deps/eigen"]
 	path = deps/eigen
 	url = https://gitlab.com/libeigen/eigen.git
+[submodule "deps/backward-cpp"]
+	path = deps/backward-cpp
+	url = https://github.com/bombela/backward-cpp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,13 @@ add_subdirectory(deps/libqasm)
 target_link_libraries(ql PUBLIC cqasm)
 
 
+# backward-cpp ----------------------------------------------------------------
+
+# Stack trace helper library, nothing functional here.
+add_subdirectory(deps/backward-cpp)
+add_backward(ql)
+
+
 #=============================================================================#
 # Testing                                                                     #
 #=============================================================================#

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -132,6 +132,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(_openql PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 endif()
 target_include_directories(_openql PRIVATE "${PYTHON_INCLUDE_DIRS}")
+add_backward(_openql)
 
 
 #=============================================================================#

--- a/src/exception.cc
+++ b/src/exception.cc
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <cerrno>
+#include "backward.hpp"
 
 namespace ql {
 
@@ -9,10 +10,62 @@ static std::string make_message(
     const std::string &msg,
     bool system = false
 ) noexcept {
-    if (system) {
-        return msg + ": " + std::strerror(errno);
-    } else {
+    try {
+
+        // Form the message string.
+        std::ostringstream ss{};
+        ss << msg;
+        if (system) {
+            ss << ": " << std::strerror(errno);
+        }
+
+        // Try to capture a stack to add that to the message.
+        try {
+
+            // Capture a stack trace.
+            backward::StackTrace trace;
+            trace.load_here(32);
+
+            // Try to remove the part of the stack trace due to this file and
+            // backward itself. But it's not particularly important, so ignore
+            // exceptions that might occur and move on.
+            try {
+                backward::TraceResolver tr;
+                tr.load_stacktrace(trace);
+                for (size_t i = 0; i < trace.size(); i++) {
+                    auto fn = tr.resolve(trace[i]);
+                    if (
+                        (fn.source.filename.find("exception.cc") == std::string::npos)
+                        && (fn.source.filename.find("backward.hpp") == std::string::npos)
+                    ) {
+                        trace.skip_n_firsts(i);
+                        break;
+                    }
+                }
+            } catch (std::exception &e) {
+                (void)e;
+            }
+
+            // Append the stack trace to the message.
+            ss << std::endl;
+            backward::Printer p{};
+            p.trace_context_size = 0;
+            p.print(trace, ss);
+
+        } catch (std::exception &e) {
+            (void)e;
+        }
+
+        return ss.str();
+
+    } catch (std::exception &e) {
+        (void)e;
+
+        // Don't abort if anything fails while forming the error message. This
+        // fallback should only fail if the mere act of copying the msg string
+        // is enough for things to die, at which point we've already lost.
         return msg;
+
     }
 }
 

--- a/tests/test_Program.py
+++ b/tests/test_Program.py
@@ -81,7 +81,7 @@ class Test_program(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             p.compile()
 
-        self.assertEqual(str(cm.exception), 'Error : compiling a program with no kernels !')
+        self.assertEqual(str(cm.exception).split('\n', maxsplit=1)[0], 'Error : compiling a program with no kernels !')
 
 
     def test_simple_program(self):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -52,13 +52,13 @@ class Test_options(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             ql.set_option('optimize', 'nope')
 
-        self.assertEqual(str(cm.exception), 'Error parsing options. The value nope is not an allowed value for --optimize !')
+        self.assertEqual(str(cm.exception).split('\n', maxsplit=1)[0], 'Error parsing options. The value nope is not an allowed value for --optimize !')
 
 
         with self.assertRaises(Exception) as cm:
             ql.set_option('scheduler', 'best')
 
-        self.assertEqual(str(cm.exception), 'Error parsing options. The value best is not an allowed value for --scheduler !')
+        self.assertEqual(str(cm.exception).split('\n', maxsplit=1)[0], 'Error parsing options. The value best is not an allowed value for --scheduler !')
 
 
     def test_get_values(self):

--- a/tests/test_unitary.py
+++ b/tests/test_unitary.py
@@ -87,7 +87,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             k.gate(u, [2])
 
-        self.assertEqual(str(cm.exception), 'Unitary \'u1\' not decomposed. Cannot be added to kernel!')
+        self.assertEqual(str(cm.exception).split('\n', maxsplit=1)[0], 'Unitary \'u1\' not decomposed. Cannot be added to kernel!')
 
     def test_unitary_wrongnumberofqubits(self):
         self.setUpClass()
@@ -103,7 +103,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             k.gate(u, [1,2])
 
-        self.assertEqual(str(cm.exception), 'Unitary \'u1\' has been applied to the wrong number of qubits. Cannot be added to kernel! 2 and not 1.000000')
+        self.assertEqual(str(cm.exception).split('\n', maxsplit=1)[0], 'Unitary \'u1\' has been applied to the wrong number of qubits. Cannot be added to kernel! 2 and not 1.000000')
     
     def test_unitary_wrongnumberofqubits_toofew(self):
         self.setUpClass()
@@ -120,7 +120,7 @@ class Test_conjugated_kernel(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             k.gate(u, [0])
 
-        self.assertEqual(str(cm.exception), 'Unitary \'u1\' has been applied to the wrong number of qubits. Cannot be added to kernel! 1 and not 2.000000')
+        self.assertEqual(str(cm.exception).split('\n', maxsplit=1)[0], 'Unitary \'u1\' has been applied to the wrong number of qubits. Cannot be added to kernel! 1 and not 2.000000')
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_unitary_decompose_I(self):
@@ -297,7 +297,7 @@ class Test_conjugated_kernel(unittest.TestCase):
             add_kernel(k)
             p.compile()
 
-        self.assertEqual(str(cm.exception), "Error: Unitary 'WRONG' is not a unitary matrix. Cannot be decomposed!(0,0) (0,0)\n(0,0) (0,0)\n")
+        self.assertEqual(str(cm.exception).split('\n\n', maxsplit=1)[0], "Error: Unitary 'WRONG' is not a unitary matrix. Cannot be decomposed!(0,0) (0,0)\n(0,0) (0,0)")
   
   # input for the unitary decomposition needs to be an array
     def test_unitary_decompose_matrixinsteadofarray(self):


### PR DESCRIPTION
Given platform support (backward supports a bunch of backends) ql::exception now does a stack trace upon construction and appends it to its exception message. It's probably not great in terms of performance, so if it slows things down it should probably be made optional at some point, but for now it should aid debugging.

Example:

```
terminate called after throwing an instance of 'ql::exception'
  what():  hello this is a test
Stack trace (most recent call last):
#8    Object "", at 0xffffffffffffffff, in 
#7    Source "../sysdeps/x86_64/start.S", line 120, in _start
#6    Object "/lib64/libc-2.26.so", at 0x2afec7550349, in __libc_start_main
#5    Source "/data/quantum/openql-work/develop/tests/test_mapper.cc", line 1434, in main
#4    Source "/data/quantum/openql-work/develop/tests/test_mapper.cc", line 79, in test_dpt
#3    Source "/data/quantum/openql-work/develop/src/program.cc", line 353, in compile
#2    Source "/data/quantum/openql-work/develop/src/arch/cc_light/cc_light_eqasm_compiler.cc", line 902, in compile
#1    Source "/data/quantum/openql-work/develop/src/arch/cc_light/cc_light_eqasm_compiler.cc", line 748, in map
#0    Source "/data/quantum/openql-work/develop/src/mapper.cc", line 2952, in Init
```

(location of the test exception was just arbitrarily chosen, of course)