### PR TITLE
Fix linkage with backward backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,11 @@ endif()
 add_subdirectory(deps/backward-cpp)
 add_backward(ql)
 
+# add_backward doesn't set INTERFACE_LINK_LIBRARIES, only LINK_LIBRARIES. That
+# goes wrong when we're compiling statically, because said libraries are shared
+# and need to be included in the final link.
+set_property(TARGET ql APPEND PROPERTY INTERFACE_LINK_LIBRARIES ${BACKWARD_LIBRARIES})
+
 
 #=============================================================================#
 # Testing                                                                     #


### PR DESCRIPTION
This fixes compilation of C++ programs when linked against OpenQL statically (as done by setup.py when the `OPENQL_BUILD_TESTS` env variable exists).