### PR TITLE
Add initialize() to Python API

### DIFF
--- a/src/openql_i.cc
+++ b/src/openql_i.cc
@@ -6,11 +6,37 @@
 
 #include "version.h"
 
+static bool initialized = false;
+
+/**
+ * Initializes the OpenQL library, for as far as this must be done. This should
+ * be called by the user (in Python) before anything else.
+ *
+ * Currently this just resets the options to their default values to give the
+ * user a clean slate to work with in terms of global variables (in case someone
+ * else has used the library in the same interpreter before them, for instance,
+ * as might happen with ipython/Jupyter in a shared notebook server, or during
+ * test suites), but it may initialize more things in the future.
+ */
+void initialize() {
+    if (initialized) {
+        QL_IOUT("re-initializing OpenQL library");
+    } else {
+        QL_IOUT("initializing OpenQL library");
+    }
+    initialized = true;
+    ql::options::reset_options();
+}
+
 std::string get_version() {
     return OPENQL_VERSION_STRING;
 }
 
 void set_option(const std::string &option_name, const std::string &option_value) {
+    if (!initialized) {
+        QL_WOUT("option set before initialize()! In the future, please call initialize() before anything else!");
+        initialize();
+    }
     ql::options::set(option_name, option_value);
 }
 
@@ -31,6 +57,10 @@ Platform::Platform(
     name(name),
     config_file(config_file)
 {
+    if (!initialized) {
+        QL_WOUT("platform constructed before initialize()! In the future, please call initialize() before anything else!");
+        initialize();
+    }
     platform = new ql::quantum_platform(name, config_file);
 }
 

--- a/src/openql_i.h
+++ b/src/openql_i.h
@@ -10,6 +10,7 @@
 #include "compiler.h"
 #include "options.h"
 
+void initialize();
 
 std::string get_version();
 

--- a/src/program.cc
+++ b/src/program.cc
@@ -356,8 +356,6 @@ void quantum_program::compile() {
     write_sweep_points(this, platform, "write_sweep_points");
 
     QL_IOUT("compilation of program '" << name << "' done.");
-
-    options::reset_options();
 }
 
 void quantum_program::compile_modular() {
@@ -416,8 +414,6 @@ void quantum_program::compile_modular() {
     compiler->compile(this);
 
     QL_IOUT("compilation of program '" << name << "' done.");
-
-    options::reset_options();
 
     compiler.reset();
 }

--- a/tests/cc/test_cc.py
+++ b/tests/cc/test_cc.py
@@ -19,7 +19,8 @@ all_qubits = range(0, num_qubits)
 class Test_central_controller(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ALAP')

--- a/tests/cqasm/test_cqasm_reader.py
+++ b/tests/cqasm/test_cqasm_reader.py
@@ -11,7 +11,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class TestcQasmReader(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option("write_qasm_files", "yes")
 

--- a/tests/test_Kernel.py
+++ b/tests/test_Kernel.py
@@ -11,7 +11,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_kernel(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ASAP')

--- a/tests/test_Platform.py
+++ b/tests/test_Platform.py
@@ -8,7 +8,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_platform(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ALAP')

--- a/tests/test_Program.py
+++ b/tests/test_Program.py
@@ -11,7 +11,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_program(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ALAP')
@@ -85,7 +86,6 @@ class Test_program(unittest.TestCase):
 
 
     def test_simple_program(self):
-        self.setUpClass()
         nqubits = 2
         k = ql.Kernel("kernel1", platf, nqubits)
         k.prepz(0)
@@ -105,7 +105,6 @@ class Test_program(unittest.TestCase):
 
 
     def test_5qubit_program(self):
-        self.setUpClass()
         nqubits=5
         p = ql.Program("a_program", platf, nqubits)
         k = ql.Kernel("a_kernel", platf, nqubits)
@@ -128,7 +127,6 @@ class Test_program(unittest.TestCase):
 
     # @unittest.skip('Gate by name not implemented')
     def test_allxy_program(self):
-        self.setUpClass()
         nqubits=7
         p = ql.Program('AllXY', platf, nqubits)
         k = ql.Kernel('AllXY_q0', platf, nqubits)

--- a/tests/test_alap_rc_schedule.py
+++ b/tests/test_alap_rc_schedule.py
@@ -13,12 +13,12 @@ class Test_Alap_Rc_Schedule(unittest.TestCase):
     config = os.path.join(curdir, "hardware_config_cc_light.json")
 
     def setUp(self):
+        ql.initialize()
         ql.set_option('scheduler', self._SCHEDULER)
         ql.set_option('output_dir', output_dir)
         ql.set_option('log_level', "LOG_NOTHING")
 
     def test_qwg(self):
-        self.setUp()
         # parameters
         v = 'qwg'
 
@@ -43,7 +43,6 @@ class Test_Alap_Rc_Schedule(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
     def test_qwg2(self):
-        self.setUp()
         # parameters
         v = 'qwg2'
         scheduler = self._SCHEDULER
@@ -78,7 +77,6 @@ class Test_Alap_Rc_Schedule(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
     def test_issue179(self):
-        self.setUp()
         # parameters
         v = 'issue179'
         scheduler = self._SCHEDULER
@@ -115,7 +113,6 @@ class Test_Alap_Rc_Schedule(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
     def test_edge(self):
-        self.setUp()
         # parameters
         v = 'edge'
         scheduler = self._SCHEDULER
@@ -143,7 +140,6 @@ class Test_Alap_Rc_Schedule(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
     def test_detuned(self):
-        self.setUp()
         # parameters
         v = 'detuned'
         scheduler = self._SCHEDULER
@@ -176,7 +172,6 @@ class Test_Alap_Rc_Schedule(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
     def test_detuned2(self):
-        self.setUp()
         # parameters
         v = 'detuned2'
         scheduler = self._SCHEDULER
@@ -209,7 +204,6 @@ class Test_Alap_Rc_Schedule(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
     def test_adriaan(self):
-        self.setUp()
         # parameters
         v = 'adriaan'
         scheduler = self._SCHEDULER
@@ -242,7 +236,6 @@ class Test_Alap_Rc_Schedule(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
     def test_1(self):
-        self.setUp()
         # parameters
         v = '1'
         scheduler = self._SCHEDULER
@@ -287,7 +280,6 @@ class Test_Alap_Rc_Schedule(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
     def test_7(self):
-        self.setUp()
         # parameters
         v = '7'
         scheduler = self._SCHEDULER

--- a/tests/test_barrier.py
+++ b/tests/test_barrier.py
@@ -10,6 +10,7 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_barrier(unittest.TestCase):
 
     def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('log_level', 'LOG_WARNING')
         ql.set_option('optimize', 'no')
@@ -22,7 +23,6 @@ class Test_barrier(unittest.TestCase):
 
     # barrier on specified qubits
     def test_barrier(self):
-        self.setUp()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         sweep_points = [1, 2]
@@ -52,7 +52,6 @@ class Test_barrier(unittest.TestCase):
 
     # barrier on specified qubits with 'wait' and duration = 0
     def test_wait_barrier(self):
-        self.setUp()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         sweep_points = [1, 2]
@@ -80,7 +79,6 @@ class Test_barrier(unittest.TestCase):
 
     # barrier on all qubits with barrier
     def test_barrier_all_1(self):
-        self.setUp()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         sweep_points = [1, 2]
@@ -126,7 +124,6 @@ class Test_barrier(unittest.TestCase):
 
     # barrier on all qubits with generalized gate API using 'barrier'
     def test_barrier_all_2(self):
-        self.setUp()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         sweep_points = [1, 2]
@@ -171,7 +168,6 @@ class Test_barrier(unittest.TestCase):
 
     # barrier on all qubits with generalized gate API using wait with duration 0
     def test_barrier_all_3(self):
-        self.setUp()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         sweep_points = [1, 2]

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -9,7 +9,9 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_basic(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
+
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('log_level', 'LOG_WARNING')

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -10,7 +10,8 @@ output_dir = os.path.join(curdir, 'test_output')
 
 class Test_bugs(unittest.TestCase):
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('use_default_gates', 'yes')
         ql.set_option('log_level', 'LOG_WARNING')
@@ -18,7 +19,6 @@ class Test_bugs(unittest.TestCase):
     # @unittest.expectedFailure
     # @unittest.skip
     def test_typecast(self):
-        self.setUpClass()
         sweep_points = [1,2]
         num_circuits = 1
         num_qubits = 2
@@ -44,7 +44,6 @@ class Test_bugs(unittest.TestCase):
 
 
     def test_operation_order_190(self):
-        self.setUpClass()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform("myPlatform", config_fn)
 
@@ -86,7 +85,6 @@ class Test_bugs(unittest.TestCase):
     # depending on stuff like Python's garbage collection to free a register.
     # The register numbers have to be hardcoded now for that reason.
     def test_stateful_behavior(self):
-        self.setUpClass()
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ALAP')
 

--- a/tests/test_cc_light.py
+++ b/tests/test_cc_light.py
@@ -9,7 +9,9 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_basic(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
+
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
 
@@ -19,14 +21,8 @@ class Test_basic(unittest.TestCase):
 
         ql.set_option('log_level', 'LOG_WARNING')
 
-    @classmethod
-    def tearDownClass(self):
-        ql.set_option("scheduler_post179", "no");
-
-
     # single qubit mask generation test
     def test_smis(self):
-        self.setUpClass()
         # You can specify a config location, here we use a default config
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
@@ -63,7 +59,6 @@ class Test_basic(unittest.TestCase):
 
     # single qubit mask generation test with custom gates
     def test_smis_with_custom_gates(self):
-        self.setUpClass()
 
         # You can specify a config location, here we use a default config
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
@@ -98,7 +93,6 @@ class Test_basic(unittest.TestCase):
     # single qubit mask generation multi-kernel test (custom with non-custom
     # gates)
     def test_smis_multi_kernel(self):
-        self.setUpClass()
 
         # You can specify a config location, here we use a default config
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
@@ -147,7 +141,6 @@ class Test_basic(unittest.TestCase):
 
 
     def test_smis_all_bundled(self):
-        self.setUpClass()
 
         # You can specify a config location, here we use a default config
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
@@ -179,7 +172,6 @@ class Test_basic(unittest.TestCase):
 
     # two qubit mask generation test
     def test_smit(self):
-        self.setUpClass()
 
         # You can specify a config location, here we use a default config
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
@@ -220,7 +212,7 @@ class Test_basic(unittest.TestCase):
 
 
     def test_smit_all_bundled(self):
-        self.setUpClass()
+
         # You can specify a config location, here we use a default config
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
@@ -254,6 +246,10 @@ class Test_basic(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
 class Test_advance(unittest.TestCase):
+
+    @classmethod
+    def setUp(self):
+        ql.initialize()
 
     def test_qubit_busy(self):
         ql.set_option('output_dir', output_dir)

--- a/tests/test_cc_light_long_duration.py
+++ b/tests/test_cc_light_long_duration.py
@@ -8,6 +8,11 @@ curdir = os.path.dirname(os.path.realpath(__file__))
 output_dir = os.path.join(curdir, 'test_output')
 
 class Test_CCL_long_duration(unittest.TestCase):
+
+    @classmethod
+    def setUp(self):
+        ql.initialize()
+
     def test_AllXY(self):
         """
         Single qubit AllXY sequence.

--- a/tests/test_commutation.py
+++ b/tests/test_commutation.py
@@ -9,6 +9,7 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_commutation(unittest.TestCase):
 
     def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option("scheduler_uniform", "no")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -9,7 +9,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_Configuration(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ALAP')
@@ -83,7 +84,6 @@ class Test_Configuration(unittest.TestCase):
 
 
     def test_missing_cc_light_instr(self):
-        self.setUpClass()
         config_fn = os.path.join(curdir, 'test_cfg_CCL_long_duration.json')
         platform  = ql.Platform('seven_qubits_chip', config_fn)
         p = ql.Program("aProgram", platform, platform.get_qubit_number())

--- a/tests/test_conjugate.py
+++ b/tests/test_conjugate.py
@@ -10,7 +10,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_conjugated_kernel(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ASAP')

--- a/tests/test_controlled_kernel.py
+++ b/tests/test_controlled_kernel.py
@@ -13,6 +13,10 @@ ql.set_option('log_level', 'LOG_WARNING')
 
 class Test_controlled_kernel(unittest.TestCase):
 
+    @classmethod
+    def setUp(self):
+        ql.initialize()
+
     def test_controlled_single_qubit_gates(self):
         config_fn = os.path.join(curdir, 'test_cfg_none_simple.json')
         platform  = ql.Platform('platform_none', config_fn)

--- a/tests/test_cqasm.py
+++ b/tests/test_cqasm.py
@@ -23,7 +23,8 @@ def file_compare(fn1, fn2):
 class Test_cqasm(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ASAP')
@@ -32,7 +33,6 @@ class Test_cqasm(unittest.TestCase):
 
 
     def test_cqasm_default_gates(self):
-        self.setUpClass() 
         ql.set_option('use_default_gates', 'yes')
 
         nqubits = 4
@@ -77,7 +77,6 @@ class Test_cqasm(unittest.TestCase):
 
     # @unittest.skip
     def test_cqasm_custom_gates(self):
-        self.setUpClass() 
         ql.set_option('use_default_gates', 'no')
 
         nqubits = 4

--- a/tests/test_custom_gate.py
+++ b/tests/test_custom_gate.py
@@ -13,6 +13,10 @@ ql.set_option('write_qasm_files', 'yes')
 
 class Test_kernel(unittest.TestCase):
 
+    @classmethod
+    def setUp(self):
+        ql.initialize()
+
     def custom_gate_test(self):
         nqubits = 1
 

--- a/tests/test_dependence.py
+++ b/tests/test_dependence.py
@@ -12,6 +12,7 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_dependence(unittest.TestCase):
 
     def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ASAP')
@@ -19,13 +20,9 @@ class Test_dependence(unittest.TestCase):
         ql.set_option('log_level', 'LOG_WARNING')
         ql.set_option('write_qasm_files', 'yes')
 
-    def tearDown(self):
-        ql.set_option('scheduler', 'ALAP')
-
     # @unittest.expectedFailure
     # @unittest.skip
     def test_independent(self):
-        self.setUp()
         nqubits = 4
         # populate kernel
         k = ql.Kernel("aKernel", platf, nqubits)
@@ -54,7 +51,6 @@ class Test_dependence(unittest.TestCase):
 
     # @unittest.skip
     def test_WAW(self):
-        self.setUp()
         nqubits = 4
         # populate kernel
         k = ql.Kernel("aKernel", platf, nqubits)
@@ -84,7 +80,6 @@ class Test_dependence(unittest.TestCase):
 
     # @unittest.skip
     def test_RAR_Control(self):
-        self.setUp()
         nqubits = 4
 
         # populate kernel
@@ -114,7 +109,6 @@ class Test_dependence(unittest.TestCase):
 
     # @unittest.skip
     def test_RAW(self):
-        self.setUp()
 
         nqubits = 4
 
@@ -146,7 +140,6 @@ class Test_dependence(unittest.TestCase):
 
     # @unittest.skip
     def test_WAR(self):
-        self.setUp()
 
         nqubits = 4
 
@@ -178,7 +171,6 @@ class Test_dependence(unittest.TestCase):
 
     # @unittest.skip
     def test_swap_single(self):
-        self.setUp()
 
         nqubits = 4
 
@@ -203,7 +195,6 @@ class Test_dependence(unittest.TestCase):
 
     # @unittest.skip
     def test_swap_multi(self):
-        self.setUp()
 
         nqubits = 5
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -6,6 +6,10 @@ curdir = os.path.dirname(os.path.realpath(__file__))
 
 class Test_basic(unittest.TestCase):
 
+    @classmethod
+    def setUp(self):
+        ql.initialize()
+
     # this test should raise exception as specified configuration
     # file does not exist
     def test_missing_config(self):

--- a/tests/test_gate_decomposition.py
+++ b/tests/test_gate_decomposition.py
@@ -12,6 +12,10 @@ ql.set_option('log_level', 'LOG_WARNING')
 
 class Tester(unittest.TestCase):
 
+    @classmethod
+    def setUp(self):
+        ql.initialize()
+
     def test_decomposition(self):
         config_fn = os.path.join(curdir, 'test_cfg_none.json')
         platform  = ql.Platform('platform_none', config_fn)

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -10,14 +10,14 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_hybrid_classical_quantum(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ALAP')
         ql.set_option('log_level', 'LOG_WARNING')
 
     def test_classical(self):
-        self.setUpClass()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         num_qubits = 5
@@ -67,7 +67,6 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
 
 
     def test_if(self):
-        self.setUpClass()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         num_qubits = 5
@@ -101,7 +100,6 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
         self.assertTrue(file_compare(QISA_fn, GOLD_fn))
 
     def test_if_else(self):
-        self.setUpClass()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         num_qubits = 5
@@ -135,7 +133,6 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
 
 
     def test_for(self):
-        self.setUpClass()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         num_qubits = 5
@@ -169,7 +166,6 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
 
 
     def test_do_while(self):
-        self.setUpClass()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         num_qubits = 5
@@ -203,7 +199,6 @@ class Test_hybrid_classical_quantum(unittest.TestCase):
 
 
     def test_do_while_nested_for(self):
-        self.setUpClass()
         config_fn = os.path.join(curdir, 'hardware_config_cc_light.json')
         platform = ql.Platform('seven_qubits_chip', config_fn)
         num_qubits = 5

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -22,6 +22,7 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_mapper(unittest.TestCase):
 
     def setUp(self):
+        ql.initialize()
         # uses defaults of options in mapper branch except for output_dir and for maptiebreak
         ql.set_option('output_dir', output_dir)     # this uses output_dir set above
         ql.set_option('maptiebreak', 'first')       # this makes behavior deterministic to cmp with golden

--- a/tests/test_minimal.py
+++ b/tests/test_minimal.py
@@ -12,7 +12,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_kernel(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
 
     def minimal(self):

--- a/tests/test_modularity.py
+++ b/tests/test_modularity.py
@@ -8,7 +8,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_modularity(unittest.TestCase):
 
   @classmethod
-  def setUpClass(self):
+  def setUp(self):
+      ql.initialize()
       ql.set_option('output_dir', output_dir)
       ql.set_option('optimize', 'no')
       ql.set_option('scheduler', 'ASAP')
@@ -19,7 +20,6 @@ class Test_modularity(unittest.TestCase):
       ql.set_option('mapper', 'minextendrc')
 
   def test_modularity(self):
-      self.setUpClass()
       config_fn = os.path.join(curdir, 'hwcfg_cc_light_modular.json')
 
       c = ql.Compiler("testCompiler")

--- a/tests/test_multi_core.py
+++ b/tests/test_multi_core.py
@@ -15,6 +15,7 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_multi_core(unittest.TestCase):
 
     def setUp(self):
+        ql.initialize()
         # uses defaults of options in mapper branch except for output_dir and for maptiebreak
         ql.set_option('output_dir', output_dir)     # this uses output_dir set above
         ql.set_option('maptiebreak', 'first')       # this makes behavior deterministic to cmp with golden

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -7,14 +7,9 @@ output_dir = os.path.join(curdir, 'test_output')
 
 class Test_options(unittest.TestCase):
 
-    def tearDown(self):
-        ql.set_option('log_level', 'LOG_NOTHING')
-        ql.set_option('optimize', 'no')
-        ql.set_option('scheduler', 'ALAP')
-        ql.set_option('scheduler_uniform', 'no')
-        ql.set_option('use_default_gates', 'yes')
-        ql.set_option('decompose_toffoli', 'no')
-
+    @classmethod
+    def setUp(self):
+        ql.initialize()
 
     def test_set_all_options(self):
         # try to set all legal values of options

--- a/tests/test_parallel_triggers.py
+++ b/tests/test_parallel_triggers.py
@@ -9,7 +9,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_parallel_trigger(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('log_level', 'LOG_WARNING')

--- a/tests/test_quantumsim.py
+++ b/tests/test_quantumsim.py
@@ -8,7 +8,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_quantumsim(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ASAP')

--- a/tests/test_qubits.py
+++ b/tests/test_qubits.py
@@ -13,7 +13,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_qubits(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ALAP')
@@ -21,7 +22,6 @@ class Test_qubits(unittest.TestCase):
         ql.set_option('write_qasm_files', 'yes')
 
     def test_1_qubit(self):
-        self.setUpClass()
         nqubits = 1
         sweep_points = [2]
 
@@ -45,7 +45,6 @@ class Test_qubits(unittest.TestCase):
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
     def test_2_qubit(self):
-        self.setUpClass()
         nqubits = 3
         sweep_points = [2]
         k = ql.Kernel("aKernel", platf, nqubits)
@@ -69,7 +68,6 @@ class Test_qubits(unittest.TestCase):
         self.assertTrue( file_compare(qasm_fn, gold_fn) )
 
     def test_3_qubit(self):
-        self.setUpClass()
         nqubits = 3
         sweep_points = [2]
 

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -15,6 +15,8 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_skip(unittest.TestCase):
 
     def setUp(self):
+        ql.initialize()
+
         ql.set_option('output_dir', output_dir)     # this uses output_dir set above
 
         ql.set_option('log_level', 'LOG_NOTHING')
@@ -34,7 +36,6 @@ class Test_skip(unittest.TestCase):
         ql.set_option('mapper', 'no')
 
     def test_skip_yes(self):
-        self.setUp()
         # just check whether skip works for trivial case
         # parameters
         ql.set_option('issue_skip_319', 'yes')

--- a/tests/test_std_experiments_CCL.py
+++ b/tests/test_std_experiments_CCL.py
@@ -18,6 +18,10 @@ ql.set_option('log_level', 'LOG_WARNING')
 @unittest.skip
 class Test_single_qubit_seqs_CCL(unittest.TestCase):
 
+    @classmethod
+    def setUp(self):
+        ql.initialize()
+
     def test_bug(self):
         p = Program("bug", platf, 1)
 

--- a/tests/test_sweep_points.py
+++ b/tests/test_sweep_points.py
@@ -11,14 +11,14 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_sweep_points(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ALAP')
         ql.set_option('log_level', 'LOG_WARNING')
             
     def test_sweep_points(self):
-        self.setUpClass()
         sweep_points = [0.25, 1, 1.5, 2, 2.25]
         nqubits = 1
 
@@ -50,7 +50,6 @@ class Test_sweep_points(unittest.TestCase):
         self.assertEqual(len(matched), len(sweep_points))
 
     def test_no_sweep_points(self):
-        self.setUpClass()
         nqubits = 1
 
         # create a kernel

--- a/tests/test_uniform_sched.py
+++ b/tests/test_uniform_sched.py
@@ -8,6 +8,10 @@ output_dir = os.path.join(curdir, 'test_output')
 
 class Test_uniform_scheduler(unittest.TestCase):
 
+    @classmethod
+    def setUp(self):
+        ql.initialize()
+
     def test_uniform_scheduler_0(self):
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')

--- a/tests/test_unitary.py
+++ b/tests/test_unitary.py
@@ -34,7 +34,8 @@ def helper_prob(qubitstate):
 class Test_conjugated_kernel(unittest.TestCase):
 
     @classmethod
-    def setUpClass(self):
+    def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('optimize', 'no')
         ql.set_option('scheduler', 'ASAP')
@@ -42,7 +43,6 @@ class Test_conjugated_kernel(unittest.TestCase):
         ql.set_option('write_qasm_files', 'yes')
 
     def test_unitary_basic(self):
-        self.setUpClass()
         num_qubits = 3
         p = ql.Program('test_unitary_pass', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -59,7 +59,6 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.compile()
 
     def test_unitary_called_hadamard(self):
-        self.setUpClass()
         num_qubits = 3
         p = ql.Program('test_unitary_called_hadamard', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -74,7 +73,6 @@ class Test_conjugated_kernel(unittest.TestCase):
         p.compile()
 	
     def test_unitary_undecomposed(self):
-        self.setUpClass()
         num_qubits = 3
         p = ql.Program('test_unitary_pass', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -90,7 +88,6 @@ class Test_conjugated_kernel(unittest.TestCase):
         self.assertEqual(str(cm.exception).split('\n', maxsplit=1)[0], 'Unitary \'u1\' not decomposed. Cannot be added to kernel!')
 
     def test_unitary_wrongnumberofqubits(self):
-        self.setUpClass()
         num_qubits = 3
         p = ql.Program('test_unitary_pass', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -106,7 +103,6 @@ class Test_conjugated_kernel(unittest.TestCase):
         self.assertEqual(str(cm.exception).split('\n', maxsplit=1)[0], 'Unitary \'u1\' has been applied to the wrong number of qubits. Cannot be added to kernel! 2 and not 1')
     
     def test_unitary_wrongnumberofqubits_toofew(self):
-        self.setUpClass()
         num_qubits = 3
         p = ql.Program('test_unitary_pass', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -124,7 +120,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_unitary_decompose_I(self):
-        self.setUpClass()
         num_qubits = 1
         p = ql.Program('test_unitary_I', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -146,7 +141,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_unitary_decompose_X(self):
-        self.setUpClass()
         num_qubits = 1
         p = ql.Program('test_unitary_X', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -168,7 +162,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_unitary_decompose_Y(self):
-        self.setUpClass()
         num_qubits = 1
         p = ql.Program('test_unitary_Y', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -190,7 +183,6 @@ class Test_conjugated_kernel(unittest.TestCase):
  
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_unitary_decompose_Z(self):
-        self.setUpClass()
         num_qubits = 1
         p = ql.Program('test_unitary_Z', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -216,7 +208,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_unitary_decompose_IYZ(self):
-        self.setUpClass()
         num_qubits = 1
         p = ql.Program('test_unitary_IYZ', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -248,7 +239,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_unitary_decompose_IYZ_differentorder(self):
-        self.setUpClass()
         num_qubits = 1
         p = ql.Program('test_unitary_IYZ', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -282,7 +272,6 @@ class Test_conjugated_kernel(unittest.TestCase):
         self.assertAlmostEqual(0.5, helper_regex(c0)[1], 5)  
 
     def test_unitary_decompose_nonunitary(self):
-        self.setUpClass()
         num_qubits = 1
         p = ql.Program('test_unitary_nonunitary', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -301,7 +290,6 @@ class Test_conjugated_kernel(unittest.TestCase):
   
   # input for the unitary decomposition needs to be an array
     def test_unitary_decompose_matrixinsteadofarray(self):
-        self.setUpClass()
         num_qubits = 1
         p = ql.Program('test_unitary_wrongtype', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -313,7 +301,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_unitary_decompose_2qubit_CNOT(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_unitary_2qubitCNOT', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -339,7 +326,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_unitary_decompose_2qubit_CNOT_2(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_unitary_2qubitCNOT', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -367,7 +353,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_non_90_degree_angle(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_unitary_non_90_degree_angle', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -394,7 +379,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_00(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_usingqx00', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -426,7 +410,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_01(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_usingqx01', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -463,7 +446,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_10(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_usingqx10', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -500,7 +482,6 @@ class Test_conjugated_kernel(unittest.TestCase):
     
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_11(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_usingqx11', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -535,7 +516,6 @@ class Test_conjugated_kernel(unittest.TestCase):
     
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_bellstate(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_usingqxbellstate', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -572,7 +552,6 @@ class Test_conjugated_kernel(unittest.TestCase):
     
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_fullyentangled(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_usingqxfullentangled', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -609,7 +588,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_fullyentangled_3qubit(self):
-        self.setUpClass()
         num_qubits = 3
         p = ql.Program('test_usingqxfullentangled_3qubit', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -675,7 +653,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_fullyentangled_4qubit(self):
-        self.setUpClass()
         num_qubits = 4
         p = ql.Program('test_usingqxfullentangled_4qubit', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -755,7 +732,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_fullyentangled_5qubit(self):
-        self.setUpClass()
         num_qubits = 5
         p = ql.Program('test_usingqxfullentangled_5qubit', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -839,7 +815,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_fullyentangled_5qubit_10011(self):
-        self.setUpClass()
         num_qubits = 5
         p = ql.Program('test_usingqxfullentangled_5qubit_10011', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -925,7 +900,6 @@ class Test_conjugated_kernel(unittest.TestCase):
         self.assertAlmostEqual(helper_prob(matrix[19+992]), helper_regex(c0)[31], 5)
 
     def test_adding2tothepower6unitary(self):
-        self.setUpClass()
         num_qubits = 6
         p = ql.Program('test_6qubitjustadding', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1074,7 +1048,6 @@ class Test_conjugated_kernel(unittest.TestCase):
     
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_usingqx_sparseunitary(self):
-        self.setUpClass()
         num_qubits = 5
         p = ql.Program('test_usingqxsparseunitary', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1153,7 +1126,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_extremelysparseunitary(self):
-        self.setUpClass()
         num_qubits = 4
         p = ql.Program('test_usingqx_extremelysparseunitary_newname', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1216,7 +1188,6 @@ class Test_conjugated_kernel(unittest.TestCase):
   
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_sparse2qubitunitary(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_usingqx_sparse2qubit', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1246,7 +1217,6 @@ class Test_conjugated_kernel(unittest.TestCase):
   
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_sparse2qubitunitaryotherqubit(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_usingqx_sparse2qubitotherqubit', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1275,7 +1245,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_sparse2qubitunitaryotherqubitcheck(self):
-        self.setUpClass()
         num_qubits = 1
         p = ql.Program('test_usingqx_sparse2qubitotherqubit_test', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1299,7 +1268,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_sparse2qubit_multiplexor(self):
-        self.setUpClass()
         num_qubits = 2
         p = ql.Program('test_usingqx_sparse2qubit_multiplexor', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1328,7 +1296,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_decomposition_rotatedtoffoli(self):
-        self.setUpClass()
         num_qubits = 3
         p = ql.Program('test_usingqx_rotatedtoffoli', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1368,7 +1335,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_decomposition_toffoli(self):
-        self.setUpClass()
         num_qubits = 3
         p = ql.Program('test_usingqx_toffoli', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1407,7 +1373,6 @@ class Test_conjugated_kernel(unittest.TestCase):
 
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_decomposition_controlled_U(self):
-        self.setUpClass()
         num_qubits = 3
         p = ql.Program('test_usingqx_toffoli', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)
@@ -1446,7 +1411,6 @@ class Test_conjugated_kernel(unittest.TestCase):
    
     @unittest.skipIf(qx is None, "qxelarator not installed")
     def test_decomposition_mscthesisaritra(self):
-        self.setUpClass()
         num_qubits = 4
         p = ql.Program('test_usingqx_mscthesisaritra', platform, num_qubits)
         k = ql.Kernel('akernel', platform, num_qubits)

--- a/tests/test_wait.py
+++ b/tests/test_wait.py
@@ -10,6 +10,7 @@ output_dir = os.path.join(curdir, 'test_output')
 class Test_wait(unittest.TestCase):
 
     def setUp(self):
+        ql.initialize()
         ql.set_option('output_dir', output_dir)
         ql.set_option('use_default_gates', 'no')
         ql.set_option('log_level', 'LOG_WARNING')

--- a/tests/visualizer/visualizer_example.py
+++ b/tests/visualizer/visualizer_example.py
@@ -4,6 +4,7 @@ import os
 curdir = os.path.dirname(__file__)
 output_dir = os.path.join(curdir, 'visualizer_example_output')
 
+ql.initialize()
 ql.set_option('output_dir', output_dir)
 ql.set_option('optimize', 'no')
 ql.set_option('scheduler', 'ASAP')


### PR DESCRIPTION
This adds `ql.initialize()` to the Python interface. It's purpose is to ensure that OpenQL is put in a well-defined, default state. Currently that only amounts to resetting options to their default values. If an option is set or a platform is constructed before initialize() is called, initialize() is called automatically and a warning is printed; this is just there for backward compatibility, and to teach people to call it themselves. The latter is necessary in the context of a shared python interpreter, such as a ipython/jupyter running on a shared server or during test suites, to prevent side-effects from the previous runs of OpenQL from affecting the latest run.

This replaces the current behavior of resetting options implicitly at the end of compile().