### PR TITLE
Maintenance

### DIFF
--- a/deps/lemon/lemon/arg_parser.cc
+++ b/deps/lemon/lemon/arg_parser.cc
@@ -221,9 +221,8 @@ namespace lemon {
                                 const std::string &opt)
   {
     Opts::iterator o = _opts.find(opt);
-    Opts::iterator s = _opts.find(syn);
     LEMON_ASSERT(o!=_opts.end(), "Unknown option: '"+opt+"'");
-    LEMON_ASSERT(s==_opts.end(), "Option already used: '"+syn+"'");
+    LEMON_ASSERT(_opts.find(syn)==_opts.end(), "Option already used: '"+syn+"'");
     ParData p;
     p.help=opt;
     p.mandatory=false;


### PR DESCRIPTION
Clean up all GCC 7.5.0 warnings, some code style stuff around the code that triggered the warnings, and bump libqasm/tree-gen with similar maintenance performed. No functional changes.