### PR TITLE
Release OpenQL 0.11.0

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
+        - '3.11'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -76,11 +76,11 @@ jobs:
         - 2014
         - _2_28
         cpython_version:
-        - 'cp36-cp36m'
         - 'cp37-cp37m'
         - 'cp38-cp38'
         - 'cp39-cp39'
         - 'cp310-cp310'
+        - 'cp311-cp311'
         include:
           - manylinux: 2014
             bison_version: 'bison-3.0.4-2.el7'
@@ -138,11 +138,11 @@ jobs:
       fail-fast: false
       matrix:
         python:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
+        - '3.11'
     steps:
     - uses: actions/checkout@v2
       with:
@@ -203,11 +203,11 @@ jobs:
 #        - macos-latest
 #        - windows-2016
 #        python-version:
-#        - '3.6'
 #        - '3.7'
 #        - '3.8'
 #        - '3.9'
 #        - '3.10'
+#        - '3.11'
 #    steps:
 #    - uses: actions/checkout@v2
 #      with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,11 +72,11 @@ jobs:
         - macos-latest
         - windows-latest
         python:
-        - '3.6'
         - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'
+        - '3.11'
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,7 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.11
   install:
     - method: setuptools
       path: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,24 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [ next ] - [ TBD ]
 ### Added
+-
+
+### Changed
+-
+
+### Removed
+-
+
+
+## [ 0.11.0 ] - [ 2023-01-06 ]
+### Added
 - CC backend:
   - support for cQASM 1.2 features through new IR 
     - limitations
       - integer values must be non-negative
   - support for resource constrained scheduler
-  - creates .map file reporting measurement statements present in input, to allow retrieving measurements downstream 
+  - creates .map file reporting measurement statements present in input, to allow retrieving measurements downstream
+- support for Python up to 3.11
 
 ### Changed
 - pass dec.Instructions: duration=0 in new-style decomposition rules now disables checking whether expansion fits, allowing automatic calculation of duration (and requiring scheduling after decomposition of such rules)
@@ -22,12 +34,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - classification of gates as *real-time* measurement now based on signal definition ("signal/type" equals "measure" and "signal/value" empty)
   - absence of key "cc" now implies empty "signal", so `"cc": { "signal": [] }` is no longer necessary
 - passes and architectures self-register statically to their respective factories
+- initial placer uses new IR and new MIP solver called HiGHS
 
 ### Removed
 - CC backend:
   - support for JSON key "pragma/break" for instruction definitions
   - macro expansion for JSON key instruction/signal/value (unused anyway)
 - support for sweep points in API and the WriteSweepPointsPass
+- support for Python up to and including 3.6
 
 ### Fixed
 - pass dec.Instructions

--- a/docs/.conda.yml
+++ b/docs/.conda.yml
@@ -1,5 +1,5 @@
 dependencies:
-    - python=3.7
+    - python=3.11
     - setuptools
     - swig
     - cmake

--- a/docs/developer/automation.rst
+++ b/docs/developer/automation.rst
@@ -21,7 +21,7 @@ The suite runs the following things:
 - the standalone C++ test, built completely out of context.
 
 The former two are run on ``ubuntu-latest``, ``macos-latest``, and ``windows-latest`` for all active Python versions
-(currently 3.6 through 3.9). The latter is only run on ``ubuntu-latest``, as it doesn't check much except inclusion
+(currently 3.7 through 3.11). The latter is only run on ``ubuntu-latest``, as it doesn't check much except inclusion
 of the project via CMake.
 
 .. note::

--- a/include/ql/version.h
+++ b/include/ql/version.h
@@ -7,4 +7,4 @@
  *
  * OPENQL_VERSION_STRING is also decoded by setup.py
 */
-#define OPENQL_VERSION_STRING "0.10.5"
+#define OPENQL_VERSION_STRING "0.11.0"

--- a/setup.py
+++ b/setup.py
@@ -265,10 +265,11 @@ setup(
         'Operating System :: Microsoft :: Windows',
 
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
 
         'Topic :: Scientific/Engineering'
     ],

--- a/tests/test_bugs.py
+++ b/tests/test_bugs.py
@@ -28,7 +28,7 @@ class Test_bugs(unittest.TestCase):
 
         qubit = 1
 
-        k.identity(np.int(qubit))
+        k.identity(int(qubit))
         k.identity(np.int32(qubit))
         k.identity(np.int64(qubit))
 


### PR DESCRIPTION
A long needed release.

### Added
- CC backend:
  - support for cQASM 1.2 features through new IR 
    - limitations
      - integer values must be non-negative
  - support for resource constrained scheduler
  - creates .map file reporting measurement statements present in input, to allow retrieving measurements downstream
- support for Python up to 3.11

### Changed
- pass dec.Instructions: duration=0 in new-style decomposition rules now disables checking whether expansion fits, allowing automatic calculation of duration (and requiring scheduling after decomposition of such rules)
- CC backend:
  - now uses new IR
  - no longer requires key "cc" to be present in instructions that define gate decompositions
  - key "readout_mode" no longer used
    - classification of gates as measurement - which is used for the resource constrained scheduler, and to output a map of measurements - now based on signal definition ("signal/type" equals "measure" and "signal/value" non-empty)
    - classification of gates as *real-time* measurement now based on signal definition ("signal/type" equals "measure" and "signal/value" empty)
  - absence of key "cc" now implies empty "signal", so `"cc": { "signal": [] }` is no longer necessary
- passes and architectures self-register statically to their respective factories
- initial placer uses new IR and new MIP solver called HiGHS

### Removed
- CC backend:
  - support for JSON key "pragma/break" for instruction definitions
  - macro expansion for JSON key instruction/signal/value (unused anyway)
- support for sweep points in API and the WriteSweepPointsPass
- support for Python up to and including 3.6
