### PR TITLE
Release 0.11.1 and fix wheel size issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 -
 
 
+## [ 0.11.1 ] - [ 2023-01-06 ]
+### Added
+- Option to enable/disable debug symbols, enabled by default
+
+### Changed
+-
+
+### Removed
+- Debug symbols in Python wheels, because of size limitation on PyPI
+
+
 ## [ 0.11.0 ] - [ 2023-01-06 ]
 ### Added
 - CC backend:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,14 @@ option(
     ${OPENQL_CHECKED_STL}
 )
 
+# Make it possible to disable inclusion of debug symbols, in particular for PyPI wheels,
+# since there is a size limit of 100MB.
+option(
+    OPENQL_DEBUG_SYMBOLS
+    "Whether debug or release binaries should include debug symbols (it makes binaries a lot larger)."
+    ON
+)
+
 
 #=============================================================================#
 # CMake weirdness and compatibility                                           #
@@ -364,9 +372,9 @@ target_include_directories(ql
 # Configure compilation.
 set_property(TARGET ql PROPERTY POSITION_INDEPENDENT_CODE ON)
 if(CMAKE_COMPILER_IS_GNUCXX)
-    target_compile_options(ql PRIVATE -Wall -Wfatal-errors -ggdb)
+    target_compile_options(ql PRIVATE -Wall -Wfatal-errors)
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-    target_compile_options(ql PRIVATE -Wall -Wfatal-errors -ggdb -Wno-unused-local-typedef)
+    target_compile_options(ql PRIVATE -Wall -Wfatal-errors -Wno-unused-local-typedef)
 elseif(MSVC)
     target_compile_options(ql PRIVATE /MP /D_USE_MATH_DEFINES /EHsc /bigobj)
 else()
@@ -376,6 +384,11 @@ endif()
 # Enable optimizations only for release builds.
 if(NOT MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
     target_compile_options(ql PRIVATE -O3)
+endif()
+
+# Add debug information only for debug builds.
+if(NOT MSVC AND OPENQL_DEBUG_SYMBOLS)
+    target_compile_options(ql PRIVATE -ggdb)
 endif()
 
 # Use a mock version of unitary.cc if WITH_UNITARY_DECOMPOSITION is false.

--- a/include/ql/version.h
+++ b/include/ql/version.h
@@ -7,4 +7,4 @@
  *
  * OPENQL_VERSION_STRING is also decoded by setup.py
 */
-#define OPENQL_VERSION_STRING "0.11.0"
+#define OPENQL_VERSION_STRING "0.11.1"

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,9 @@ class build_ext(_build_ext):
 
                 # Build type can be set using an environment variable.
                 ['-DCMAKE_BUILD_TYPE=' + build_type]
+
+                # Do not include debug symbols in the wheels.
+                ['-DOPENQL_DEBUG_SYMBOLS=OFF']
             )
 
             # If we're on Windows, we're probably building with MSVC. In that


### PR DESCRIPTION
PyPI no longer accept our wheels because their size on Linux/GCC just went over 100MB.
The solution is to skip including the debug symbols, which slims down the binaries to <10MB.

Debug symbols are only used when running a debugger like GDB. Or with coredumps. Normally we don't need them in the wheels.