### PR TITLE
Removed compilation warnings.

### DIFF
--- a/include/ql/ir/prim.h
+++ b/include/ql/ir/prim.h
@@ -26,7 +26,7 @@ namespace prim {
  * generated tree nodes to ensure that there's no garbage in the nodes.
  */
 template <class T>
-T initialize() { return T(); };
+T initialize() { return T(); }
 
 /**
  * Serializes the given primitive object to CBOR.
@@ -195,28 +195,28 @@ public:
      * Creates an empty matrix.
      */
     Matrix()
-        : data(ncols), nrows(1), ncols(0)
+        : data(0), nrows(1), ncols(0)
     {}
 
     /**
      * Creates a vector.
      */
-    Matrix(utils::UInt ncols)
-        : data(ncols), nrows(1), ncols(ncols)
+    explicit Matrix(utils::UInt cols)
+        : data(cols), nrows(1), ncols(cols)
     {}
 
     /**
      * Creates a zero-initialized matrix of the given size.
      */
-    Matrix(utils::UInt nrows, utils::UInt ncols)
-        : data(nrows*ncols), nrows(nrows), ncols(ncols)
+    Matrix(utils::UInt rows, utils::UInt cols)
+        : data(rows*cols), nrows(rows), ncols(cols)
     {}
 
     /**
      * Creates a column vector with the given data.
      */
-    Matrix(const utils::Vec<T> &data)
-        : data(data), nrows(data.size()), ncols(1)
+    explicit Matrix(const utils::Vec<T> &vec)
+        : data(vec), nrows(vec.size()), ncols(1)
     {}
 
     /**
@@ -224,12 +224,14 @@ public:
      * the number of data elements is not divisible by the number of columns, a
      * range error is thrown.
      */
-    Matrix(const utils::Vec<T> &data, utils::UInt ncols)
-        : data(data), nrows(data.size() / ncols), ncols(ncols)
+    Matrix(const utils::Vec<T> &vec, utils::UInt cols)
     {
-        if (data.size() % ncols != 0) {
+        if (vec.size() % cols != 0) {
             throw utils::Exception("invalid matrix shape");
         }
+        data = vec;
+        nrows = vec.size() / cols;
+        ncols = cols;
     }
 
     /**

--- a/src/ql/arch/cc/pass/gen/vq1asm/detail/backend.cc
+++ b/src/ql/arch/cc/pass/gen/vq1asm/detail/backend.cc
@@ -169,7 +169,7 @@ void Backend::codegen_block(const ir::BlockBaseRef &block, const Str &name, Int 
                     QL_ICE("unsupported conditional instruction type encountered" << "'" <<ir::describe(stmt) << "'");
                 }
 
-            } else if (auto wait = stmt->as_wait_instruction()) {
+            } else if (stmt->as_wait_instruction()) {
                 // NB: waits are already accounted for during scheduling, so backend can ignore these
                 QL_DOUT("wait (ignored by backend)");
 

--- a/src/ql/arch/cc/pass/gen/vq1asm/detail/functions.cc
+++ b/src/ql/arch/cc/pass/gen/vq1asm/detail/functions.cc
@@ -66,7 +66,7 @@ void Functions::dispatch(const ir::FunctionCall *fn, const Str &label_if_false, 
 }
 
 
-UInt Functions::emit_bin_cast(utils::Vec<utils::UInt> bregs, Int expOpCnt) {
+UInt Functions::emit_bin_cast(utils::Vec<utils::UInt> bregs, UInt expOpCnt) {
     if(bregs.size() != expOpCnt) {
         QL_ICE("Expected " << expOpCnt << " breg operands, got " << bregs.size());
     }
@@ -75,7 +75,7 @@ UInt Functions::emit_bin_cast(utils::Vec<utils::UInt> bregs, Int expOpCnt) {
     UInt smAddr = 0;
     UInt mask = 0;      // mask for used SM bits in 32 bit word transferred using move_sm
     Str descr;
-    for (Int i=0; i<bregs.size(); i++) {
+    for (UInt i=0; i<bregs.size(); i++) {
         auto breg = bregs[i];
         if(breg >= NUM_BREGS) {
             QL_INPUT_ERROR("bit register index " << breg << " exceeds maximum of " << NUM_BREGS-1);   // FIXME: cleanup "breg" vs. "bit register index"
@@ -145,7 +145,7 @@ void Functions::op_linv_B(const FncArgs &a) {
 
 void Functions::op_grp_bit_2op_BB(const FncArgs &a) {
     // transfer 2 bregs to REG_TMP0
-    UInt mask = emit_bin_cast(a.ops.bregs, 2);
+    (void) emit_bin_cast(a.ops.bregs, 2);
 
 #if 0    // FIXME: handle operation properly, this is just copy/paste from op_linv
     cs.emit("", "and", QL_SS2S(REG_TMP0 << "," << mask << "," << REG_TMP1));    // results in '0' for 'bit==0' and 'mask' for 'bit==1'

--- a/src/ql/arch/cc/pass/gen/vq1asm/detail/functions.h
+++ b/src/ql/arch/cc/pass/gen/vq1asm/detail/functions.h
@@ -36,7 +36,7 @@ public:
      * FIXME: We don't have a matching quantum instruction for this cast (formerly, we had 'if_1_break' etc), but do
      *  take up 'quantum' time, so the timeline is silently shifted
      */
-    UInt emit_bin_cast(utils::Vec<utils::UInt> bregs, Int expOpCnt);
+    UInt emit_bin_cast(utils::Vec<utils::UInt> bregs, UInt expOpCnt);
 
 
 private:  // types

--- a/src/ql/ir/new_to_old.cc
+++ b/src/ql/ir/new_to_old.cc
@@ -779,7 +779,7 @@ void NewToOldConverter::convert_block(
                     throw;
                 }
 
-            } else if (auto for_loop = stmt->as_for_loop()) {
+            } else if (stmt->as_for_loop()) {
                 QL_ICE("unsupported for loop encountered");
 
             } else {

--- a/src/ql/ir/old_to_new.cc
+++ b/src/ql/ir/old_to_new.cc
@@ -193,7 +193,7 @@ static void parse_decomposition_rule(
     cqasm::ReadOptions read_options;
     read_options.schedule_mode = cqasm::ScheduleMode::KEEP;
     for (const auto &operand_type : ityp->operand_types) {
-        utils::Bool assignable;
+        utils::Bool assignable{ false };
         switch (operand_type->mode) {
             case prim::OperandMode::BARRIER:
             case prim::OperandMode::WRITE:


### PR DESCRIPTION
- backend.cc: removed unused variable 'wait'.
- functions.cc/.h: changed 'expOpCnt' parameter type from Int to UInt, to avoid a signed/unsigned comparison. The same for the for loop variable 'i'.
- new_to_old.cc: removed unused variable 'for_loop'.
- old_to_new.cc: initialize 'assignable' boolean variable, to avoid its use when uninitialized.
- prim.h:
  - Warnings complained about 'data' being initialized from an uninitialized 'ncols'. This may be a false positive, due to the constructor parameter being called like the member variable. Anyway, it can be easily fixed by renaming the parameter (having parameter names equal to member names can be quite confusing).
  - made constructors receiving one single parameter explicit.
  - removed an extra semicolon at the end of the initialize function template.