### PR TITLE
fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,11 +13,10 @@ formats:
   - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
-python:
-  version: 3.11
-  install:
-    - method: setuptools
-      path: .
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
 
 submodules:
   include: all


### PR DESCRIPTION
* changed os/python settings. We used the old interface that is now deprecated (this lead to the error)
* changed extension yml to yaml as it is used by readthedocs itself in all the examples